### PR TITLE
Add rules for i18n linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+v1.1.0 (March 8, 2016)
+======================
+
+- New rule: [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md)
+- New rule: [`i18n-no-variables`](docs/rules/i18n-no-variables.md)
+- New rule: [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md)
+- New rule: [`i18n-mismatched-placeholders`](docs/rules/i18n-mismatched-placeholders.md)
+- New rule: [`i18n-named-placeholders`](docs/rules/i18n-named-placeholders.md)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Then configure the rules you want to use under the rules section.
 ## Supported Rules
 
 - [`no-lodash-import`](docs/rules/no-lodash-import.md): Disallow importing from the root Lodash module
+- [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Then configure the rules you want to use under the rules section.
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
 - [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md): Disallow strings which include only placeholders
 - [`i18n-mismatched-placeholders`](docs/rules/i18n-mismatched-placeholders.md): Ensure placeholder counts match between singular and plural strings
+- [`i18n-named-placeholders`](docs/rules/i18n-named-placeholders.md): Disallow multiple unnamed placeholders
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then configure the rules you want to use under the rules section.
 - [`no-lodash-import`](docs/rules/no-lodash-import.md): Disallow importing from the root Lodash module
 - [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
+- [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md): Disallow strings which include only placeholders
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Then configure the rules you want to use under the rules section.
 
 - [`no-lodash-import`](docs/rules/no-lodash-import.md): Disallow importing from the root Lodash module
 - [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
+- [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then configure the rules you want to use under the rules section.
 - [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
 - [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md): Disallow strings which include only placeholders
+- [`i18n-mismatched-placeholders`](docs/rules/i18n-mismatched-placeholders.md): Ensure placeholder counts match between singular and plural strings
 
 ## License
 

--- a/docs/rules/i18n-ellipsis.md
+++ b/docs/rules/i18n-ellipsis.md
@@ -1,0 +1,17 @@
+# Disallow using three dots in translate strings
+
+Three dots for indicating an ellipsis should be replaced with the UTF-8 character … (Horizontal Ellipsis, U+2026) as it has a more semantic meaning.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( 'Loading...' );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Loading…' );
+```

--- a/docs/rules/i18n-mismatched-placeholders.md
+++ b/docs/rules/i18n-mismatched-placeholders.md
@@ -1,0 +1,25 @@
+# Ensure placeholder counts match between singular and plural strings
+
+When using placeholders in strings, there cannot be a mismatch between the number of placeholders in the single and plural variants of the string. Not all languages use the singular form only for a single count. For example, some use the singular form for counts of 21, 31, etc. If there should be a different string for 1 or 0, special case it in the code.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+var count = 21;
+translate( 'One thing', '%d things', {
+	count: count,
+	args: [ count ]
+} );
+```
+
+The following patterns are not warnings:
+
+```js
+var count = 21;
+translate( '%d thing', '%d things', {
+	count: count,
+	args: [ count ]
+} );
+```

--- a/docs/rules/i18n-named-placeholders.md
+++ b/docs/rules/i18n-named-placeholders.md
@@ -1,0 +1,24 @@
+# Disallow multiple unnamed placeholders
+
+Translators need to be able to change the order of strings, so multiple placeholders in a translation should be named.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( '%s %s', {
+	args: [ 'Hello', 'World' ]
+} );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( '%(greeting)s %(toWhom)s', {
+	args: {
+		greeting: 'Hello',
+		toWhom: 'World'
+	}
+} );
+```

--- a/docs/rules/i18n-no-placeholders-only.md
+++ b/docs/rules/i18n-no-placeholders-only.md
@@ -1,0 +1,17 @@
+# Disallow strings which include only placeholders
+
+Strings cannot be translated if they consist only of placeholders.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( '%s' );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Hello %s!' );
+```

--- a/docs/rules/i18n-no-variables.md
+++ b/docs/rules/i18n-no-variables.md
@@ -2,6 +2,8 @@
 
 Translate strings cannot be variables or functions, but rather must always be string literals. This is a limitation of our translation tooling, as it collects strings through static analysis of the code. The exception to this rule is string concatenation within the argument itself.
 
+This limitation applies to the translatable string itself, as well as the plural form and 'context' and 'comment' options if they are present.
+
 More information: https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only
 
 ## Rule Details

--- a/docs/rules/i18n-no-variables.md
+++ b/docs/rules/i18n-no-variables.md
@@ -1,0 +1,23 @@
+# Disallow variables as translate strings
+
+Translate strings cannot be variables or functions, but rather must always be string literals. This is a limitation of our translation tooling, as it collects strings through static analysis of the code. The exception to this rule is string concatenation within the argument itself.
+
+More information: https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( myString );
+
+translate( myStringFunc() );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Hello World!' );
+
+translate( 'Hello' + ' World!' );
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,4 +17,4 @@ var requireIndex = require( 'requireindex' );
 //------------------------------------------------------------------------------
 
 // import all rules in lib/rules
-module.exports.rules = requireIndex( './rules' );
+module.exports.rules = requireIndex( __dirname + '/rules' );

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -30,7 +30,7 @@ var rule = module.exports = function( context ) {
 
 				if ( -1 !== arg.value.indexOf( '...' ) ) {
 					context.report( {
-						node: node,
+						node: arg,
 						message: rule.ERROR_MESSAGE,
 						fix: function( fixer ) {
 							return fixer.replaceText( arg, arg.raw.replace( /\.\.\./g, '…' ) );

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Disallow using three dots in translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getSequenceCallee = require( '../util/sequence-callee' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			if ( 'translate' !== getSequenceCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg ) {
+				if ( 'Literal' !== arg.type || 'string' !== typeof arg.value ) {
+					return;
+				}
+
+				if ( -1 !== arg.value.indexOf( '...' ) ) {
+					context.report( {
+						node: node,
+						message: rule.ERROR_MESSAGE,
+						fix: function( fixer ) {
+							return fixer.replaceText( arg, arg.raw.replace( /\.\.\./g, '…' ) );
+						}
+					} );
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'Use ellipsis character (…) in place of three dots';
+
+rule.schema = [];

--- a/lib/rules/i18n-mismatched-placeholders.js
+++ b/lib/rules/i18n-mismatched-placeholders.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Ensure placeholder counts match between singular and plural strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RX_PLACEHOLDERS = /(?:\x25\x25)|(\x25(?:(?:[1-9]\d*)\$|\((?:[^\)]+)\))?(?:\+)?(?:0|'[^$])?(?:-)?(?:\d+)?(?:\.(?:\d+))?(?:[b-fiosuxX]))/g;
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getSequenceCallee = require( '../util/sequence-callee' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			var singular, plural, singularMatch, pluralMatch;
+			if ( 'translate' !== getSequenceCallee( node ).name ) {
+				return;
+			}
+
+			// Only consider translate calls with plurals specified
+			if ( node.arguments.length !== 3 ) {
+				return;
+			}
+
+			singular = node.arguments[ 0 ].value;
+			plural = node.arguments[ 1 ].value;
+
+			// Ignore invalid arguments
+			if ( 'string' !== typeof singular || 'string' !== typeof plural ) {
+				return;
+			}
+
+			singularMatch = singular.match( RX_PLACEHOLDERS );
+			pluralMatch = plural.match( RX_PLACEHOLDERS );
+
+			// Ignore strings without any placeholders
+			if ( ! singularMatch && ! pluralMatch ) {
+				return;
+			}
+
+			if ( ( singularMatch && ! pluralMatch ) ||
+					( ! singularMatch && pluralMatch ) ||
+					( singularMatch.length !== pluralMatch.length ) ) {
+				context.report( node, rule.ERROR_MESSAGE );
+			}
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'Should have same number of placeholders between singular and plural';
+
+rule.schema = [];

--- a/lib/rules/i18n-named-placeholders.js
+++ b/lib/rules/i18n-named-placeholders.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Disallow multiple unnamed placeholders
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+var rule;
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RX_PLACEHOLDERS = /(?:\x25\x25)|(\x25(?:(?:[1-9]\d*)\$|\((?:[^\)]+)\))?(?:\+)?(?:0|'[^$])?(?:-)?(?:\d+)?(?:\.(?:\d+))?(?:[b-fiosuxX]))/g;
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getSequenceCallee = require( '../util/sequence-callee' );
+
+function hasUnqualifiedPlaceholders( string ) {
+	var placeholders = string.match( RX_PLACEHOLDERS ) || []
+	if ( placeholders.length <= 1 ) {
+		return false;
+	}
+
+	return placeholders.some( function( placeholder ) {
+		return ! placeholder.match( /[0-9()]/ );
+	} );
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			var singular, plural;
+			if ( 'translate' !== getSequenceCallee( node ).name ) {
+				return;
+			}
+
+			// Find unqualified placeholders in singular
+			singular = node.arguments[ 0 ].value;
+			if ( 'string' === typeof singular && hasUnqualifiedPlaceholders( singular ) ) {
+				context.report( node, rule.ERROR_MESSAGE );
+				return;
+			}
+
+			// Done if no plural string exists
+			if ( node.arguments.length <= 1 ) {
+				return;
+			}
+
+			// Find unqualified placeholders in plural
+			plural = node.arguments[ 1 ].value;
+			if ( 'string' === typeof plural && hasUnqualifiedPlaceholders( plural ) ) {
+				context.report( node, rule.ERROR_MESSAGE );
+			}
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'Multiple placeholders should be named';
+
+rule.schema = [];

--- a/lib/rules/i18n-named-placeholders.js
+++ b/lib/rules/i18n-named-placeholders.js
@@ -46,7 +46,7 @@ rule = module.exports = function( context ) {
 			// Find unqualified placeholders in singular
 			singular = node.arguments[ 0 ].value;
 			if ( 'string' === typeof singular && hasUnqualifiedPlaceholders( singular ) ) {
-				context.report( node, rule.ERROR_MESSAGE );
+				context.report( node.arguments[ 0 ], rule.ERROR_MESSAGE );
 				return;
 			}
 
@@ -58,7 +58,7 @@ rule = module.exports = function( context ) {
 			// Find unqualified placeholders in plural
 			plural = node.arguments[ 1 ].value;
 			if ( 'string' === typeof plural && hasUnqualifiedPlaceholders( plural ) ) {
-				context.report( node, rule.ERROR_MESSAGE );
+				context.report( node.arguments[ 1 ], rule.ERROR_MESSAGE );
 			}
 		}
 	};

--- a/lib/rules/i18n-no-placeholders-only.js
+++ b/lib/rules/i18n-no-placeholders-only.js
@@ -38,13 +38,13 @@ var rule = module.exports = function( context ) {
 
 				value = value.replace( RX_PLACEHOLDERS, '' );
 				if ( 0 === value.length ) {
-					context.report( node, rule.ERROR_MESSAGE );
+					context.report( arg, rule.ERROR_MESSAGE );
 					return;
 				}
 
 				value = value.replace( RX_INTERPOLATED_COMPONENTS, '' );
 				if ( 0 === value.length ) {
-					context.report( node, rule.ERROR_MESSAGE );
+					context.report( arg, rule.ERROR_MESSAGE );
 				}
 			} );
 		}

--- a/lib/rules/i18n-no-placeholders-only.js
+++ b/lib/rules/i18n-no-placeholders-only.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Disallow strings which include only placeholders
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RX_PLACEHOLDERS = /(?:\x25\x25)|(\x25(?:(?:[1-9]\d*)\$|\((?:[^\)]+)\))?(?:\+)?(?:0|'[^$])?(?:-)?(?:\d+)?(?:\.(?:\d+))?(?:[b-fiosuxX]))/g;
+var RX_INTERPOLATED_COMPONENTS = /(\{\{\/?\s*\w+\s*\/?\}\})/g;
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getSequenceCallee = require( '../util/sequence-callee' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			if ( 'translate' !== getSequenceCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg ) {
+				var value = arg.value;
+				if ( 'Literal' !== arg.type || 'string' !== typeof value ) {
+					return;
+				}
+
+				value = value.replace( RX_PLACEHOLDERS, '' );
+				if ( 0 === value.length ) {
+					context.report( node, rule.ERROR_MESSAGE );
+					return;
+				}
+
+				value = value.replace( RX_INTERPOLATED_COMPONENTS, '' );
+				if ( 0 === value.length ) {
+					context.report( node, rule.ERROR_MESSAGE );
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'We shouldn\'t translate strings that are entirely placeholder';
+
+rule.schema = [];

--- a/lib/rules/i18n-no-variables.js
+++ b/lib/rules/i18n-no-variables.js
@@ -17,8 +17,13 @@ var getSequenceCallee = require( '../util/sequence-callee' );
 //------------------------------------------------------------------------------
 
 var rule = module.exports = function( context ) {
+	function isAcceptableLiteralNode( node ) {
+		return 'Literal' === node.type || 'BinaryExpression' === node.type;
+	}
+
 	return {
 		CallExpression: function( node ) {
+			var options;
 			if ( 'translate' !== getSequenceCallee( node ).name ) {
 				return;
 			}
@@ -30,8 +35,26 @@ var rule = module.exports = function( context ) {
 					return;
 				}
 
-				if ( 'Literal' !== arg.type && 'BinaryExpression' !== arg.type ) {
-					context.report( node, rule.ERROR_MESSAGE );
+				if ( ! isAcceptableLiteralNode( arg ) ) {
+					context.report( arg, rule.ERROR_MESSAGE );
+				}
+			} );
+
+			// Done if no options
+			options = node.arguments[ node.arguments.length - 1 ];
+			if ( ! options || options.type !== 'ObjectExpression' ) {
+				return;
+			}
+
+			// Verify that context and comment are non-variable
+			options.properties.forEach( function( property ) {
+				var key = property.key.name;
+				if ( key !== 'context' && key !== 'comment' ) {
+					return;
+				}
+
+				if ( ! isAcceptableLiteralNode( property.value ) ) {
+					context.report( property, rule.ERROR_MESSAGE );
 				}
 			} );
 		}

--- a/lib/rules/i18n-no-variables.js
+++ b/lib/rules/i18n-no-variables.js
@@ -18,7 +18,13 @@ var getSequenceCallee = require( '../util/sequence-callee' );
 
 var rule = module.exports = function( context ) {
 	function isAcceptableLiteralNode( node ) {
-		return 'Literal' === node.type || 'BinaryExpression' === node.type;
+		if ( 'BinaryExpression' === node.type ) {
+			return '+' === node.operator &&
+				isAcceptableLiteralNode( node.left ) &&
+				isAcceptableLiteralNode( node.right );
+		}
+
+		return 'Literal' === node.type;
 	}
 
 	return {

--- a/lib/rules/i18n-no-variables.js
+++ b/lib/rules/i18n-no-variables.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Disallow variables as translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getSequenceCallee = require( '../util/sequence-callee' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			if ( 'translate' !== getSequenceCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg, i ) {
+				// Ignore last argument in multi-argument translate call, which
+				// should be the object argument
+				if ( i === node.arguments.length - 1 && node.arguments.length > 1 ) {
+					return;
+				}
+
+				if ( 'Literal' !== arg.type && 'BinaryExpression' !== arg.type ) {
+					context.report( node, rule.ERROR_MESSAGE );
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'Variables cannot be used as translate strings';
+
+rule.schema = [];

--- a/lib/rules/i18n-no-variables.js
+++ b/lib/rules/i18n-no-variables.js
@@ -60,7 +60,7 @@ var rule = module.exports = function( context ) {
 				}
 
 				if ( ! isAcceptableLiteralNode( property.value ) ) {
-					context.report( property, rule.ERROR_MESSAGE );
+					context.report( property.value, rule.ERROR_MESSAGE );
 				}
 			} );
 		}

--- a/lib/util/sequence-callee.js
+++ b/lib/util/sequence-callee.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Utility for retrieving first non-sequence callee from a CallExpression node
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+/**
+ * Returns the first non-sequence callee from a CallExpression node.
+ *
+ * @param  {Object} node CallExpression node
+ * @return {Object}      First non-sequence callee
+ */
+module.exports = function( node ) {
+	var callee = node.callee;
+	while ( 'SequenceExpression' === callee.type ) {
+		callee = callee.expressions[ callee.expressions.length - 1 ];
+	}
+
+	return callee;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Disallow using three dots in translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-ellipsis' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-ellipsis', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hello World…\' );'
+		},
+		{
+			code: 'translate( \'Hello World…\', \'Hello Worlds…\' );'
+		},
+		{
+			code: '( 0, translate )( \'Hello World…\' );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( \'Hello World...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World…\', \'Hello Worlds...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: '( 0, translate )( \'Hello World...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/i18n-mismatched-placeholders.js
+++ b/tests/lib/rules/i18n-mismatched-placeholders.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Ensure placeholder counts match between singular and plural strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-mismatched-placeholders' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-mismatched-placeholders', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hello %s\' );'
+		},
+		{
+			code: 'translate( \'Hello %s\', \'Hello %s\' );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( \'One thing\', \'%s things\', { count: 2 } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'%s thing\', \'Many things\', { count: 2 } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'%s%s\', \'%s\', { count: 2 } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/i18n-named-placeholders.js
+++ b/tests/lib/rules/i18n-named-placeholders.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Disallow multiple unnamed placeholders
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-named-placeholders' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-named-placeholders', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hello %s\' );'
+		},
+		{
+			code: 'translate( \'%1s %2s\' );'
+		},
+		{
+			code: 'translate( \'%(greeting)s %(toWhom)s\' );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( \'%s %s\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'%(greeting)s %s\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello %s\', \'%s %s\', { count: 2 } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/i18n-no-placeholders-only.js
+++ b/tests/lib/rules/i18n-no-placeholders-only.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Disallow strings which include only placeholders
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-placeholders-only' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-no-placeholders-only', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hello %s\' );'
+		},
+		{
+			code: 'translate( \'Hello %(toWhom)s\' );'
+		},
+		{
+			code: 'translate( \'%s%%s\' );'
+		},
+		{
+			code: 'translate( \'{{example}}Hello World{{/example}}\' );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( \'%s%d\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World\', \'%s%d\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'{{example}}%s{{/example}}\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/i18n-no-variables.js
+++ b/tests/lib/rules/i18n-no-variables.js
@@ -66,6 +66,12 @@ var rule = require( '../../../lib/rules/i18n-no-variables' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE
 			} ]
+		},
+		{
+			code: 'translate( \'Hello \' + name );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
 		}
 	]
 } );

--- a/tests/lib/rules/i18n-no-variables.js
+++ b/tests/lib/rules/i18n-no-variables.js
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Disallow variables as translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-variables' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-no-variables', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hello World\' );'
+		},
+		{
+			code: 'translate( \'Hello\' + \' World\' );'
+		},
+		{
+			code: 'translate( \'Hello World\', {} );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( string );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World\', plural, {} );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/i18n-no-variables.js
+++ b/tests/lib/rules/i18n-no-variables.js
@@ -27,6 +27,12 @@ var rule = require( '../../../lib/rules/i18n-no-variables' ),
 		},
 		{
 			code: 'translate( \'Hello World\', {} );'
+		},
+		{
+			code: 'translate( \'Hello World\', { context: "a literal" } );'
+		},
+		{
+			code: 'translate( \'A literal key\', { \'context\': "A literal" } );'
 		}
 	],
 
@@ -39,6 +45,24 @@ var rule = require( '../../../lib/rules/i18n-no-variables' ),
 		},
 		{
 			code: 'translate( \'Hello World\', plural, {} );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World\', { context: aVariable } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World\', { context: aFunctionCall() } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Hello World\', { comment: aVariable } );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE
 			} ]

--- a/tests/lib/util/sequence-callee.js
+++ b/tests/lib/util/sequence-callee.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Utility for retrieving first non-sequence callee from a CallExpression node
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+var assert = require( 'assert' );
+var getSequenceCallee = require( '../../../lib/util/sequence-callee' );
+
+describe( '#getSequenceCallee', function() {
+	it( 'should return non-sequence callee', function() {
+		var node, callee;
+		node = {
+			type: 'CallExpression',
+			callee: {
+				type: 'Identifier',
+				name: 'translate'
+			}
+		};
+		callee = getSequenceCallee( node );
+
+		assert.equal( callee, node.callee );
+	} );
+
+	it( 'should return first non-sequence callee expression', function() {
+		var node, callee;
+		node = {
+			type: 'CallExpression',
+			callee: {
+				type: 'SequenceExpression',
+				expressions: [ {
+					type: 'Literal',
+					value: 0
+				}, {
+					type: 'Identifier',
+					name: 'translate'
+				} ]
+			}
+		};
+		callee = getSequenceCallee( node );
+
+		assert.equal( callee, node.callee.expressions[ 1 ] );
+	} );
+} );


### PR DESCRIPTION
This pull request seeks to deprecate [Calypso's `i18nlint` script](https://github.com/Automattic/wp-calypso/tree/master/server/i18nlint) by instead providing equivalent ESLint rules.

Benefits include:
- Simplifies linting
- Faster `pre-commit` checks, since `i18nlint` is no longer a separate script to run against each file
- CircleCI build failures on i18n lint errors
- More visibility to errors, including inline warning display when using ESLint editor plugin
- Autofix! Implemented here for `i18n-ellipsis` rule

**Testing instructions:**

Verify tests pass by running `npm test`.

/cc @deBhal , @rralian , @gziolo 
