### PR TITLE
Add/string template support for i18n-no-variables

### DIFF
--- a/lib/rules/i18n-no-variables.js
+++ b/lib/rules/i18n-no-variables.js
@@ -30,6 +30,12 @@ var rule = module.exports = function( context ) {
 				isAcceptableLiteralNode( node.right );
 		}
 
+		if ( 'TemplateLiteral' === node.type ) {
+			// Backticks are fine, but if there's any interpolation in it,
+			// that's a problem
+			return node.expressions.length === 0;
+		}
+
 		return 'Literal' === node.type;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/i18n-no-variables.js
+++ b/tests/lib/rules/i18n-no-variables.js
@@ -11,13 +11,14 @@
 //------------------------------------------------------------------------------
 
 var rule = require( '../../../lib/rules/i18n-no-variables' ),
+	config = { env: { es6: true } },  // support for string templates
 	RuleTester = require( 'eslint' ).RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-( new RuleTester() ).run( 'i18n-no-variables', rule, {
+( new RuleTester( config ) ).run( 'i18n-no-variables', rule, {
 	valid: [
 		{
 			code: 'translate( \'Hello World\' );'
@@ -39,6 +40,12 @@ var rule = require( '../../../lib/rules/i18n-no-variables' ),
 		},
 		{
 			code: 'translate( { original: { single: \'Hello World\' } } );'
+		},
+		{
+			code: 'translate( `Hello World` );'
+		},
+		{
+			code: 'translate( `Multi\nline\nstring\ntemplate` );'
 		}
 	],
 
@@ -87,6 +94,12 @@ var rule = require( '../../../lib/rules/i18n-no-variables' ),
 		},
 		{
 			code: 'translate( { original: { single: string } } );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: '/*eslint-env es6*/ translate( `Hello ${World}!` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE
 			} ]


### PR DESCRIPTION
Address #5 by adding support for string template literals in the i18n-no-variables.

This PR aims to support the string template literal syntax, by allowing string templates with no interpolation.  e.g. `translate( `Some plain string` );` should be acceptable, while `translate( `A string with some ${interpolation}` );` is not.

_NOTE:_ wp-calypso's `get-i18n` does not support string templates yet.  This PR is not ready to merge until that's been fixed.
