### PR TITLE
Add rule `jsx-classname-namespace` for enforcing CSS namespace guidelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.3.0 (June 16, 2016)
+
+- New rule: [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md)
+
 #### v1.2.0 (June 9, 2016)
 
 - New rule: [`jsx-gridicon-size`](docs/rules/jsx-gridicon-size.md)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -26,3 +26,28 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
+
+Templated message formatting replacement adapted from [`ESLint`](https://github.com/eslint/eslint), maintained by the jQuery Foundation and other contributors, released under the MIT License:
+
+```text
+ESLint
+Copyright jQuery Foundation and other contributors, https://jquery.org/
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Then configure the rules you want to use under the rules section.
 
 ## Supported Rules
 
+- [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md): Ensure JSX className adheres to CSS namespace guidelines
 - [`no-lodash-import`](docs/rules/no-lodash-import.md): Disallow importing from the root Lodash module
 - [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings

--- a/docs/rules/jsx-classname-namespace.md
+++ b/docs/rules/jsx-classname-namespace.md
@@ -1,0 +1,43 @@
+# Ensure JSX className adheres to CSS namespace guidelines
+
+If JSX element includes `className`, it must include the containing directory name as the component name for the root element, or as a component prefix for child elements (with `__` separating component and element names).
+
+[See Calypso CSS guidelines for more information](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md)
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+// client/sample-component/index.js
+export default function() {
+	return <div className="sample" />;
+}
+
+// client/another-sample/index.js
+export default function() {
+	return (
+		<div className="another-sample">
+			<div className="another-sample-child" />
+		</div>
+	);
+}
+```
+
+The following patterns are not warnings:
+
+```js
+// client/sample-component/index.js
+export default function() {
+	return <div className="sample-component" />;
+}
+
+// client/another-sample/index.js
+export default function() {
+	return (
+		<div className="another-sample">
+			<div className="another-sample__child" />
+		</div>
+	);
+}
+```

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview Ensure JSX className adheres to CSS namespace guidelines
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var path = require( 'path' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	function isModuleExportNode( node ) {
+		return (
+			'ExpressionStatement' === node.type &&
+			'AssignmentExpression' === node.expression.type &&
+			'MemberExpression' === node.expression.left.type &&
+			'module' === node.expression.left.object.name &&
+			'exports' === node.expression.left.property.name
+		);
+	}
+
+	function isIdentifierInDescendents( node, name ) {
+		switch ( node.type ) {
+			case 'Identifier':
+				return node.name === name;
+
+			case 'CallExpression':
+				return node.arguments.some( function( argNode ) {
+					return isIdentifierInDescendents( argNode, name );
+				} );
+		}
+
+		return false;
+	}
+
+	function isRenderFunction( node ) {
+		if ( 'FunctionExpression' !== node.type ) {
+			return false;
+		}
+
+		if ( 'Property' === node.parent.type ) {
+			return 'init' === node.parent.kind && 'render' === node.parent.key.name;
+		}
+
+		if ( 'MethodDefinition' === node.parent.type ) {
+			return 'render' === node.parent.key.name;
+		}
+
+		return false;
+	}
+
+	function isRootRenderedElement( node ) {
+		var parent = node.parent.parent.parent,
+			functionExpression, functionName;
+
+		// If wrapped in a JSX element, the node is a child
+		if ( 'JSXElement' === parent.type ) {
+			return false;
+		}
+
+		do {
+			if ( -1 !== [ 'FunctionExpression', 'FunctionDeclaration', 'ArrowFunctionExpression' ].indexOf( parent.type ) ) {
+				functionExpression = parent;
+
+				// If inside function expression, check that the name of the
+				// property is "render" (React.createClass or Component class)
+				if ( isRenderFunction( parent ) ) {
+					return true;
+				}
+
+				// If wrapped in function declaration, check the declaration
+				// is part of a default export (stateless function component)
+				switch ( parent.type ) {
+					case 'ArrowFunctionExpression':
+					case 'FunctionDeclaration':
+						if ( 'ExportDefaultDeclaration' === parent.parent.type ||
+								isModuleExportNode( parent.parent ) ) {
+							return true;
+						}
+						break;
+
+					case 'FunctionExpression':
+						if ( 'AssignmentExpression' === parent.parent.type &&
+								isModuleExportNode( parent.parent.parent ) ) {
+							return true;
+						}
+				}
+			}
+
+			// If we've exhausted parent options, check to see whether exports
+			// refer to last visited function expression
+			if ( 'Program' === parent.type && functionExpression ) {
+				switch ( functionExpression.type ) {
+					case 'FunctionDeclaration':
+						if ( functionExpression.id ) {
+							functionName = functionExpression.id.name;
+						}
+						break;
+
+					case 'ArrowFunctionExpression':
+						if ( 'VariableDeclarator' === functionExpression.parent.type ) {
+							functionName = functionExpression.parent.id.name;
+						}
+						break;
+				}
+
+				return !! functionName && parent.body.some( function( programNode ) {
+					if ( 'ExportDefaultDeclaration' === programNode.type ) {
+						return isIdentifierInDescendents( programNode.declaration, functionName );
+					}
+
+					// `module.exports` assignment, check that right-side
+					// assignment value matches function name
+					if ( isModuleExportNode( programNode ) ) {
+						return isIdentifierInDescendents( programNode.expression.right, functionName );
+					}
+
+					return false;
+				} );
+			}
+
+			parent = parent.parent;
+		} while ( parent );
+
+		return false;
+	}
+
+	return {
+		JSXAttribute: function( node ) {
+			var rawClassName, classNames, isError, isRoot, namespace;
+
+			if ( 'className' !== node.name.name ) {
+				return;
+			}
+
+			if ( 'JSXExpressionContainer' === node.value.type ) {
+				rawClassName = node.value.expression;
+			} else {
+				rawClassName = node.value;
+			}
+
+			if ( 'Literal' !== rawClassName.type || 'string' !== typeof rawClassName.value ) {
+				return;
+			}
+
+			classNames = rawClassName.value.split( ' ' );
+			namespace = path.basename( path.dirname( context.getFilename() ) );
+			isRoot = isRootRenderedElement( node );
+			isError = ! classNames.some( function( className ) {
+				if ( isRoot ) {
+					return className === namespace;
+				}
+
+				return 0 === className.indexOf( namespace + '__' );
+			} );
+
+			if ( isError ) {
+				context.report( {
+					node: node,
+					message: rule.ERROR_MESSAGE
+				} );
+			}
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines';
+
+rule.schema = [];

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -135,7 +135,7 @@ var rule = module.exports = function( context ) {
 
 	return {
 		JSXAttribute: function( node ) {
-			var rawClassName, classNames, isError, isRoot, namespace;
+			var rawClassName, classNames, isError, isRoot, namespace, expected;
 
 			if ( 'className' !== node.name.name ) {
 				return;
@@ -162,16 +162,26 @@ var rule = module.exports = function( context ) {
 				return 0 === className.indexOf( namespace + '__' );
 			} );
 
-			if ( isError ) {
-				context.report( {
-					node: node,
-					message: rule.ERROR_MESSAGE
-				} );
+			if ( ! isError ) {
+				return;
 			}
+
+			expected = namespace;
+			if ( ! isRoot ) {
+				expected += '__ prefix';
+			}
+
+			context.report( {
+				node: node,
+				message: rule.ERROR_MESSAGE,
+				data: {
+					expected: expected
+				}
+			} );
 		}
 	};
 };
 
-rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines';
+rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines (expected {{expected}})';
 
 rule.schema = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -1,0 +1,298 @@
+/**
+ * @fileoverview Ensure JSX className adheres to CSS namespace guidelines
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'jsx-classname-namespace', rule, {
+	valid: [
+		{
+			code: 'export default function() { return <Foo className="foo" />; }',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default function() { return <Foo className="quux foo" />; }',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default () => <Foo className="foo" />;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'const Foo = () => <Foo className="foo" />; export default Foo;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'import localize from "./localize"; const Foo = () => <Foo className="foo" />; export default localize( localize( Foo ) );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'import connect from "./connect"; const Foo = () => <Foo className="foo" />; export default connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'const Foo = () => <Foo className="foo" />; module.exports = Foo;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'const localize = require( "./localize" ); const Foo = () => <Foo className="foo" />; module.exports = localize( localize( Foo ) );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'const connect = require( "./connect" ); const Foo = () => <Foo className="foo" />; module.exports = connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'function Foo() { return <Foo className="foo" />; } export default Foo;',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'module.exports = function() { return <Foo className="foo" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default React.createClass( { render: function() { return <Foo className="foo" />; } } );',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default React.createClass( { render() { return <Foo className="foo"><div className="foo__child" /></Foo>; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default React.createClass( { child() { return <div className="foo__child" />; }, render() { return <Foo className="foo" />; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'function child() { return <Foo className="foo__child" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'function child() { return <Foo className="quux foo__child" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default class Foo { render() { return <Foo className="foo" />; } }',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'import localize from "./localize"; class Foo { render() { return <Foo className="foo" />; } } export default localize( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'import connect from "./connect"; class Foo { render() { return <Foo className="foo" />; } } export default connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'export default function() { return <Foo className="foobar" />; }',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default function() { return <Foo className="quux foobar" />; }',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default () => <Foo className="foobar" />;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'const Foo = () => <Foo className="foobar" />; export default Foo;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'import localize from "./localize"; const Foo = () => <Foo className="foobar" />; export default localize( localize( Foo ) );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'import connect from "./connect"; const Foo = () => <Foo className="foobar" />; export default connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'const Foo = () => <Foo className="foobar" />; module.exports = Foo;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'const localize = require( "./localize" ); const Foo = () => <Foo className="foobar" />; module.exports = localize( localize( Foo ) );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'const connect = require( "./connect" ); const Foo = () => <Foo className="foobar" />; module.exports = connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'function Foo() { return <Foo className="foobar" />; } export default Foo;',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'module.exports = function() { return <Foo className="foobar" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default React.createClass( { render: function() { return <Foo className="foobar" />; } } );',
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default React.createClass( { render() { return <Foo className="foo"><div className="foobar__child" /></Foo>; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default React.createClass( { child() { return <div className="foobar__child" />; }, render() { return <Foo className="foo" />; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'function child() { return <Foo className="foobar__child" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'function child() { return <Foo className="quux foobar__child" />; }',
+			ecmaFeatures: { jsx: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'export default class Foo { render() { return <Foo className="foobar" />; } }',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'import localize from "./localize"; class Foo { render() { return <Foo className="foobar" />; } } export default localize( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'import connect from "./connect"; class Foo { render() { return <Foo className="foobar" />; } } export default connect()( Foo );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -6,12 +6,45 @@
  */
 'use strict';
 
+var EXPECTED_FOO_ERROR, EXPECTED_FOO_PREFIX_ERROR;
+
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
 var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Utility
+//------------------------------------------------------------------------------
+
+/**
+ * Given a message containing data terms, format the string using the specified
+ * terms object.
+ *
+ * @see https://github.com/eslint/eslint/blob/v2.12.0/lib/eslint.js#L964-L971
+ *
+ * @param  {String} message Message template
+ * @param  {Object} terms   Terms
+ * @return {String}         Formatted message
+ */
+function formatMessage( message, terms ) {
+	return message.replace( /\{\{\s*(.+?)\s*\}\}/g, function( fullMatch, term ) {
+		if ( terms.hasOwnProperty( term ) ) {
+			return terms[ term ];
+		}
+
+		return fullMatch;
+	} );
+}
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+EXPECTED_FOO_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo' } );
+EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo__ prefix' } );
 
 //------------------------------------------------------------------------------
 // Tests
@@ -134,7 +167,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -142,7 +175,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -151,7 +184,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -160,7 +193,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -169,7 +202,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -178,7 +211,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -187,7 +220,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -196,7 +229,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -205,7 +238,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -214,7 +247,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -222,7 +255,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -230,7 +263,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -239,7 +272,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
 		},
 		{
@@ -248,7 +281,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
 		},
 		{
@@ -256,7 +289,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
 		},
 		{
@@ -264,7 +297,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
 		},
 		{
@@ -273,7 +306,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -282,7 +315,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		},
 		{
@@ -291,7 +324,7 @@ var rule = require( '../../../lib/rules/jsx-classname-namespace' ),
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',
 			errors: [ {
-				message: rule.ERROR_MESSAGE
+				message: EXPECTED_FOO_ERROR
 			} ]
 		}
 	]


### PR DESCRIPTION
This pull request seeks to introduce a new rule, `jsx-classname-prefix`, which produces an error when the `className` of a JSX element does not adhere to the namespace guidelines from the Calypso CSS documentation:

https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/css.md

**Testing instructions:**
1. Clone repository and checkout branch `add/jsx-classname-prefix`
2. `npm install`
3. `npm ln`
4. Change to directory containing [wp-calypso repository](https://github.com/Automattic/wp-calypso.git)
5. `npm ln eslint-plugin-wpcalypso`
6. `./node_modules/.bin/eslint --rule 'wpcalypso/jsx-classname-namespace: 2' client/layout/index.jsx`
7. Note three errors are produced, corresponding with `wp-content`, `wp-primary`, and `wp-secondary` elements

``` text
/Users/andrew/Documents/Code/wp-calypso/client/layout/index.jsx
  200:23  error  Incorrect usage of CSS namespace  wpcalypso/jsx-classname-namespace
  205:24  error  Incorrect usage of CSS namespace  wpcalypso/jsx-classname-namespace
  206:26  error  Incorrect usage of CSS namespace  wpcalypso/jsx-classname-namespace
```

Ensure Mocha tests pass by running `npm test`.

/cc @mtias 
