### PR TITLE
Update link to i18n-calypso documentation

### DIFF
--- a/docs/rules/i18n-no-variables.md
+++ b/docs/rules/i18n-no-variables.md
@@ -4,7 +4,7 @@ Translate strings cannot be variables or functions, but rather must always be st
 
 This limitation applies to the translatable string itself, as well as the plural form and 'context' and 'comment' options if they are present.
 
-More information: https://wpcalypso.wordpress.com/devdocs/client/lib/mixins/i18n#strings-only
+More information: https://github.com/Automattic/i18n-calypso/blob/master/README.md#strings-only
 
 ## Rule Details
 


### PR DESCRIPTION
A bit of context:
We have recently merged https://github.com/Automattic/wp-calypso/pull/5477 which moved i18n to an external repository.
This PR just updates the link to the documentation.
