### PR TITLE
jsx-classname-namespace: Check all ancestors as JSXElement for non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.3.1 (June 17, 2016)
+
+- Fix: jsx-classname-namespace: JSX child expressions should not be considered root elements
+
 #### v1.3.0 (June 16, 2016)
 
 - New rule: [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md)

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -61,12 +61,12 @@ var rule = module.exports = function( context ) {
 		var parent = node.parent.parent.parent,
 			functionExpression, functionName;
 
-		// If wrapped in a JSX element, the node is a child
-		if ( 'JSXElement' === parent.type ) {
-			return false;
-		}
-
 		do {
+			// If wrapped in a JSX element, the node is a child
+			if ( 'JSXElement' === parent.type ) {
+				return false;
+			}
+
 			if ( -1 !== [ 'FunctionExpression', 'FunctionDeclaration', 'ArrowFunctionExpression' ].indexOf( parent.type ) ) {
 				functionExpression = parent;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -126,6 +126,12 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js'
 		},
 		{
+			code: 'const isOk = true; export default React.createClass( { render() { return <Foo className="foo">{ isOk && <div className="foo__child" /> }</Foo>; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js'
+		},
+		{
 			code: 'export default React.createClass( { child() { return <div className="foo__child" />; }, render() { return <Foo className="foo" />; } } );',
 			env: { es6: true },
 			ecmaFeatures: { jsx: true, modules: true },
@@ -268,6 +274,15 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 		},
 		{
 			code: 'export default React.createClass( { render() { return <Foo className="foo"><div className="foobar__child" /></Foo>; } } );',
+			env: { es6: true },
+			ecmaFeatures: { jsx: true, modules: true },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
+			} ]
+		},
+		{
+			code: 'const isOk = true; export default React.createClass( { render() { return <Foo className="foo">{ isOk && <div className="foobar__child" /> }</Foo>; } } );',
 			env: { es6: true },
 			ecmaFeatures: { jsx: true, modules: true },
 			filename: '/tmp/foo/index.js',


### PR DESCRIPTION
This pull request seeks to resolve a false positive in the `jsx-classname-namespace` rule where the following child would incorrectly be considered as a root element and require the base namespace:

``` js
<Foo className="foo">{ isOk && <div className="foo__child" /> }</Foo>
```

The solution is to check that any ancestor element is a JSXElement type, returning false from `isRootRenderedElement` if encountered.

**Testing instructions:**

Ensure Mocha tests pass:

```
npm test
```

/cc @deBhal 
