### PR TITLE
jsx-classname-namespace: Don't consider non-index as root

### DIFF
--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -13,6 +13,12 @@
 var path = require( 'path' );
 
 //------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var REGEXP_INDEX_PATH = /\/index\.jsx?$/;
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -72,9 +78,13 @@ var rule = module.exports = function( context ) {
 		return false;
 	}
 
-	function isRootRenderedElement( node ) {
+	function isRootRenderedElement( node, filename ) {
 		var parent = node.parent.parent,
 			functionExpression, functionName, isRoot;
+
+		if ( ! REGEXP_INDEX_PATH.test( filename ) ) {
+			return false;
+		}
 
 		do {
 			parent = parent.parent;
@@ -161,7 +171,7 @@ var rule = module.exports = function( context ) {
 
 	return {
 		JSXAttribute: function( node ) {
-			var rawClassName, classNames, isError, isRoot, namespace, expected;
+			var rawClassName, filename, classNames, isError, isRoot, namespace, expected;
 
 			if ( 'className' !== node.name.name ) {
 				return;
@@ -177,9 +187,10 @@ var rule = module.exports = function( context ) {
 				return;
 			}
 
+			filename = context.getFilename();
 			classNames = rawClassName.value.split( ' ' );
-			namespace = path.basename( path.dirname( context.getFilename() ) );
-			isRoot = isRootRenderedElement( node );
+			namespace = path.basename( path.dirname( filename ) );
+			isRoot = isRootRenderedElement( node, filename );
 
 			// `null` return value indicates intent to abort validation
 			if ( null === isRoot ) {

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -184,6 +184,11 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			code: 'import { render } from "react-dom"; render( <div className="quux"><div className="quux__child" /></div>, document.body );',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default function() { return <div className="foo__child" />; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo-child.js'
 		}
 	],
 
@@ -360,6 +365,14 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js',
 			errors: [ {
 				message: EXPECTED_FOO_ERROR
+			} ]
+		},
+		{
+			code: 'export default function() { return <div className="foo" />; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo-child.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
 		}
 	]


### PR DESCRIPTION
For files in a directory which are not `index.js`, we should not consider the component, even the default exported component, to be "root", since we assume the root is only the default export from `index.js`

/cc @belcherj @mtias 
