### PR TITLE
Add i18n-no-newlines rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
 	"parser": "babel-eslint",
 	"env": {
 		"mocha": true,
-		"node": true
+		"node": true,
+		"es6": true
 	},
 	"rules": {
 		"brace-style": [ 2, "1tbs" ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v1.3.4 (July 29, 2016)
+
+- Add: i18n-no-newlines: Warn on newlines in translatable text
+
 #### v1.3.3 (June 28, 2016)
 
 - Fix: jsx-classname-namespace: Only consider components in index.js(x) as being eligible for root export

--- a/docs/rules/i18n-no-newlines.md
+++ b/docs/rules/i18n-no-newlines.md
@@ -1,0 +1,33 @@
+# Disallow newlines in translatable strings
+
+While it's not wrong to include newlines in translatable strings, it is
+exceptional.
+
+Newlines in translatable strings go into the translation system
+and the length of lines in different languages varies significantly. It is
+better to manage this variance using the design of elements on the page. Trying
+to manage it with text inappropriately pushes design responisibilties onto
+translators.
+
+The only time it is appropriate to include newlines is in full prose, for
+example, translating an entire email or blog post. These cases are unlikey to
+occur in the code scanned by eslint. If they do, this rule should be disabled by
+appending a comment to the line: `// eslint-disable-line i18n-no-newlines`
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( "My string\non two lines" );
+translate( 'My string\non two lines' );
+translate( `My string
+on two lines` );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Hello World!' ) + '<br>' + translate( 'More text on another line' );
+translate( '<p>Hello' + ' World!</p>' );
+```

--- a/lib/rules/i18n-no-newlines.js
+++ b/lib/rules/i18n-no-newlines.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Disallow newlines in translatable strings.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getCallee = require( '../util/get-callee' );
+var getI18nStringFromNode = require( '../util/get-i18n-string-from-node' );
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			if ( 'translate' !== getCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg ) {
+				var string = getI18nStringFromNode( arg );
+
+				if ( ! string ) {
+					return;
+				}
+
+				if ( -1 !== string.indexOf( '\n' ) ) {
+					context.report( {
+						node: arg,
+						message: rule.ERROR_MESSAGE,
+					} );
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = "Translations usually don't contain newlines";
+
+rule.schema = [];

--- a/lib/util/get-callee.js
+++ b/lib/util/get-callee.js
@@ -26,4 +26,4 @@ var getCallee = module.exports = function( node ) {
 	}
 
 	return callee;
-}
+};

--- a/lib/util/get-i18n-string-from-node.js
+++ b/lib/util/get-i18n-string-from-node.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Utility for retrieving the final translatable string from an AST
+ * node for tests that focus on the strings themselves.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+/**
+ * Approximates the string that the i18n system will process, by abstracting
+ * away the difference between TemplateLiteral and Literal strings and
+ * processing literal string concatenation.
+ *
+ * Note that TemplateLiterals with expressions are not supported, because
+ * they don't work in our translation system.
+ *
+ * @param  {Object} node A Literal, TemplateLiteral or BinaryExpression (+) node
+ * @return String   The concatenated string.
+ */
+var getStringLeafNodes = require( './get-string-leaf-nodes' );
+
+function getI18nStringFromNode( node ) {
+	// We need to handle two cases:
+	// TemplateLiteral quasis =>  node.value.raw
+	// Literal strings => node.value
+	// We don't need to handle TeplateLiterals with multiple quasis, because
+	// we don't support expressions in literals.
+	return getStringLeafNodes( node )
+		.map( function( leaf ) {
+			return leaf.value.raw || leaf.value;
+		} )
+		.join( '' );
+}
+
+ module.exports = getI18nStringFromNode;

--- a/lib/util/get-string-leaf-nodes.js
+++ b/lib/util/get-string-leaf-nodes.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Utility for retrieving the nodes that contribute to the final
+ string.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+function getStringLeafNodes( node ) {
+	if ( node.type === 'BinaryExpression' && node.operator === '+' ) {
+		return getStringLeafNodes( node.left ).concat( getStringLeafNodes( node.right ) );
+	}
+
+	if ( node.type === 'Literal' && 'string' === typeof node.value ) {
+		return [ node ];
+	}
+
+	// template literals are specced at https://github.com/babel/babylon/blob/master/ast/spec.md
+	if ( node.type === 'TemplateLiteral' ) {
+		return node.quasis;
+	}
+
+	return [];
+}
+
+ module.exports = getStringLeafNodes;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/i18n-no-newlines.js
+++ b/tests/lib/rules/i18n-no-newlines.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Disallow using three dots in translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-newlines' ),
+	config = { env: { es6: true } },  // support for string templates
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( config ) ).run( 'i18n-no-newlines', rule, {
+	valid: [
+		{
+			code: 'this.translate( \'Hello World…\' );'
+		},
+		{
+			code: 'i18n.translate( \'Hello World…\' );'
+		},
+		{
+			code: "translate( 'Hello World!' ) + '<br>' + translate( 'More text on another line' );"
+		},
+		{
+			code: "translate( '<p>Hello' + ' World!</p>' );"
+		},
+	],
+
+	invalid: [
+		{
+			code: 'translate( "My double-quoted string\\nwith a newline" );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: "translate( 'My single quoted string\\nwith a newline' );",
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( `My template literal\non two lines` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+	]
+} );

--- a/tests/lib/util/get-i18n-string-from-node.js
+++ b/tests/lib/util/get-i18n-string-from-node.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Utility for retrieving callee identifier node from a CallExpression
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+var assert = require( 'assert' );
+var getStringFromNode = require( '../../../lib/util/get-i18n-string-from-node.js' );
+var config = require( '../../../.eslintrc.json' );
+var parser = require( config.parser );
+
+function getTranslatableStringsFromCode( code ) {
+	var programNode = parser.parse( code, config.env );
+	// Espree thinks it's parsing a whole program, so we just need to peel away
+	// the 'Program' packaging.
+	var stringNode = programNode.body[ 0 ].expression;
+	return getStringFromNode( stringNode );
+}
+
+describe( '#getStringFromNode', function() {
+	it( 'should return simple strings', function() {
+		assert.equal( 'a simple string', getTranslatableStringsFromCode( "'a simple string'" ) );
+	} );
+
+	it( 'should return concatentated strings', function() {
+		assert.equal( 'A string in two parts', getTranslatableStringsFromCode( '"A string" + " in two parts"' ) );
+	} );
+
+	it( 'should return strings from template literals', function() {
+		assert.equal( 'A template literal string', getTranslatableStringsFromCode( '`A template literal string`' ) );
+	} );
+
+	it( 'should handle different literal types', function() {
+		assert.equal( 'A template and a string', getTranslatableStringsFromCode( '`A template` + " and a string"' ) );
+	} );
+} );
+


### PR DESCRIPTION
This PR adds a new rule to catch newlines in translatable strings. We've seen newlines turning up in translatable strings where they shouldn't be related to the increasing use of literal templates, but not using newlines is a pretty good rule of thumb.

The README has a more complete justification.

In the process I noticed that the other i18n rules weren't handling templates, so I've been enthusiastic about breaking out functionality I think will be useful for those.
