### PR TITLE
Fix i18n literal template support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
 	"parser": "babel-eslint",
 	"env": {
 		"mocha": true,
-		"node": true
+		"node": true,
+		"es6": true
 	},
 	"rules": {
 		"brace-style": [ 2, "1tbs" ],

--- a/docs/rules/i18n-no-newlines.md
+++ b/docs/rules/i18n-no-newlines.md
@@ -1,0 +1,33 @@
+# Disallow newlines in translatable strings
+
+While it's not wrong to include newlines in translatable strings, it is
+exceptional.
+
+Newlines in translatable strings go into the translation system
+and the length of lines in different languages varies significantly. It is
+better to manage this variance using the design of elements on the page. Trying
+to manage it with text inappropriately pushes design responisibilties onto
+translators.
+
+The only time it is appropriate to include newlines is in full prose, for
+example, translating an entire email or blog post. These cases are unlikey to
+occur in the code scanned by eslint. If they do, this rule should be disabled by
+appending a comment to the line: `// eslint-disable-line i18n-no-newlines`
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( "My string\non two lines" );
+translate( 'My string\non two lines' );
+translate( `My string
+on two lines` );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Hello World!' ) . '<br>' . translate( 'More text on another line' );
+translate( '<p>Hello' + ' World!</p>' );
+```

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 var getCallee = require( '../util/get-callee' );
+var getStringFromNode = require( '../util/get-string-from-node' );
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -24,16 +25,15 @@ var rule = module.exports = function( context ) {
 			}
 
 			node.arguments.forEach( function( arg ) {
-				if ( 'Literal' !== arg.type || 'string' !== typeof arg.value ) {
-					return;
-				}
-
-				if ( -1 !== arg.value.indexOf( '...' ) ) {
+				if ( -1 !== getStringFromNode( arg ).indexOf( '...' ) ) {
 					context.report( {
 						node: arg,
 						message: rule.ERROR_MESSAGE,
 						fix: function( fixer ) {
-							return fixer.replaceText( arg, arg.raw.replace( /\.\.\./g, '…' ) );
+							if ( arg.type === 'Literal' ) {
+								return fixer.replaceText( arg, arg.raw.replace( /\.\.\./g, '…' ) );
+							}
+							// TODO: Fix template literals.
 						}
 					} );
 				}

--- a/lib/rules/i18n-no-newlines.js
+++ b/lib/rules/i18n-no-newlines.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Disallow newlines in translatable strings.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getCallee = require( '../util/get-callee' );
+var getStringFromNode = require( '../util/get-string-from-node' );
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	return {
+		CallExpression: function( node ) {
+			if ( 'translate' !== getCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg ) {
+				var string = getStringFromNode( arg );
+
+				if ( ! string ) {
+					return;
+				}
+
+				if ( -1 !== string.indexOf( '\n' ) ) {
+					context.report( {
+						node: arg,
+						message: rule.ERROR_MESSAGE,
+					} );
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'No newlines in translations unless you REALLY mean it';
+
+rule.schema = [];

--- a/lib/util/get-string-from-node.js
+++ b/lib/util/get-string-from-node.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Utility for retrieving the final translatable string from an AST
+ * node for tests that focus on the strings themselves.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+/**
+ * Returns the singular and maybe plural strings from a CallExpression.
+ *
+ * @param  {Object} node CallExpression node
+ * @return {Object}      First non-sequence callee
+ */
+var getStringLeafNodes = require( './get-string-leaf-nodes' );
+
+function getStringFromNode( node ) {
+	// We need to handle two cases:
+	// TemplateLiteral quasis =>  node.value.raw
+	// Literal strings => node.value
+	return getStringLeafNodes( node )
+		.map( ( leaf ) => leaf.value.raw || leaf.value )
+		.join( '' );
+}
+
+ module.exports = getStringFromNode;

--- a/lib/util/get-string-leaf-nodes.js
+++ b/lib/util/get-string-leaf-nodes.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Utility for retrieving the nodes that contribute to the final
+ string.
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+function getStringLeafNodes( node ) {
+	if ( node.type === 'BinaryExpression' && node.operator === '+' ) {
+		return getStringLeafNodes( node.left ).concat( getStringLeafNodes( node.right ) );
+	};
+
+	if ( node.type === 'Literal' && 'string' === typeof node.value ) {
+		return [ node ]
+	}
+
+	// template literals are specced at https://github.com/babel/babylon/blob/master/ast/spec.md
+	if ( node.type === 'TemplateLiteral' ) {
+		return node.quasis;
+	}
+
+	return [];
+}
+
+ module.exports = getStringLeafNodes;

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -11,13 +11,14 @@
 //------------------------------------------------------------------------------
 
 var rule = require( '../../../lib/rules/i18n-ellipsis' ),
+	config = { env: { es6: true } },  // support for string templates
 	RuleTester = require( 'eslint' ).RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-( new RuleTester() ).run( 'i18n-ellipsis', rule, {
+( new RuleTester( config ) ).run( 'i18n-ellipsis', rule, {
 	valid: [
 		{
 			code: 'this.translate( \'Hello World…\' );'
@@ -66,6 +67,12 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE
 			} ]
-		}
+		},
+		{
+			code: 'this.translate( `Hello World...` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
 	]
 } );

--- a/tests/lib/rules/i18n-no-newlines.js
+++ b/tests/lib/rules/i18n-no-newlines.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Disallow using three dots in translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-newlines' ),
+	config = { env: { es6: true } },  // support for string templates
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( config ) ).run( 'i18n-no-newlines', rule, {
+	valid: [
+		{
+			code: 'this.translate( \'Hello World…\' );'
+		},
+		{
+			code: 'i18n.translate( \'Hello World…\' );'
+		},
+		{
+			code: "translate( 'Hello World!' ) + '<br>' + translate( 'More text on another line' );"
+		},
+		{
+			code: "translate( '<p>Hello' + ' World!</p>' );"
+		},
+	],
+
+	invalid: [
+		{
+			code: 'translate( "My single quotedstring\\nwith a newline" );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: "translate( 'My double-quoted string\\nwith a newline' );",
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( `My template literal\non two lines` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+	]
+} );

--- a/tests/lib/util/get-string-from-node.js
+++ b/tests/lib/util/get-string-from-node.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Utility for retrieving callee identifier node from a CallExpression
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+
+var assert = require( 'assert' );
+var getStringFromNode = require( '../../../lib/util/get-string-from-node.js' );
+var config = require( '../../../.eslintrc.json' );
+var parser = require( config.parser )
+
+function getTranslatableStringsFromCode( code ) {
+	var programNode = parser.parse( code, config.env );
+	// Espree thinks it's parsing a whole program, so we just need to peel away
+	// the 'Program' packaging.
+	var stringNode = programNode.body[0].expression;
+	return getStringFromNode( stringNode );
+}
+
+describe( '#getStringFromNode', function() {
+	it( 'should return simple strings', function() {
+		assert.equal( 'a simple string', getTranslatableStringsFromCode( "'a simple string'" ) );
+	} );
+
+	it( 'should return concatentated strings', function() {
+		assert.equal( 'A string in two parts', getTranslatableStringsFromCode( '"A string" + " in two parts"' ) );
+	} );
+
+	it( 'should return strings from template literals', function() {
+		assert.equal( 'A template literal string', getTranslatableStringsFromCode( '`A template literal string`' ) );
+	} );
+
+	it( 'should handle different literal types', function() {
+		assert.equal( 'A template and a string', getTranslatableStringsFromCode( '`A template` + " and a string"' ) );
+	} );
+} );
+


### PR DESCRIPTION
Depends on #14. Fixes #13 (i18n rules ignoring strings in backticks)

This PR fixes the existing i18n rules to support template literals (backticks).
-  [x] i18n-ellipses
- [ ] named-placeholders
- [ ] mismatched placeholders
- [ ] no-placeholders-only
- [ ] no-variables
