### PR TITLE
Add mocha devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "requireindex": "^1.1.0"
   },
   "devDependencies": {
+    "mocha": "2.3.4",
     "babel-eslint": "^6.1.0",
     "eslint": "^2.13.1"
   },


### PR DESCRIPTION
`mocha` was missing as a devDependency:

```
$ npm test

> eslint-plugin-wpcalypso@1.4.0 test eslint-plugin-wpcalypso
> npm run tests & npm run lint


> eslint-plugin-wpcalypso@1.4.0 lint eslint-plugin-wpcalypso
> eslint lib/ tests/


> eslint-plugin-wpcalypso@1.4.0 tests eslint-plugin-wpcalypso
> mocha tests --recursive

sh: mocha: command not found
```
