### PR TITLE
Fix jsx-classname-namespace regex not matching Window paths

### DIFF
--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -16,7 +16,7 @@ var path = require( 'path' );
 // Constants
 //------------------------------------------------------------------------------
 
-var REGEXP_INDEX_PATH = /\/index\.jsx?$/;
+var REGEXP_INDEX_PATH = /(\\|\/)index\.jsx?$/;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -154,6 +154,12 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js'
 		},
 		{
+			code: 'export default class FooWindows { render() { return <FooWindows className="foo" />; } }',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: 'C:\\tmp\\foo\\index.js'
+		},
+		{
 			code: 'import localize from "./localize"; class Foo { render() { return <Foo className="foo" />; } } export default localize( Foo );',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },


### PR DESCRIPTION
The regex only matched `/index.jsx` in Unix paths (e.g. `path/to/index.jsx`), now in Windows paths (e.g. `C:\path\to\index.jsx`) too.
