### PR TITLE
jsx-classname-namespace: Mark element in render as root only if returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### v2.0.0 (---)
 
 - Breaking: Required Node version increased to >=0.12.0
+- Fix: `jsx-classname-namespace` can accurately validate elements assigned to variables within render ([#21](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/21))
 - Fix: `npm test` is now run synchronously so it exits with a non-zero code on failure
 - Fix: Replace ES2015 variable (`let`) declarations to accommodate older Node versions
 - Fix: Remove unintended debugging statement from i18n-no-newlines rule

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -88,6 +88,15 @@ var rule = module.exports = function( context ) {
 
 	function getFunctionReturnValue( node ) {
 		var i, bodyNode;
+
+		// An arrow function expression is one whose return statement is
+		// implicit. It does not have a body block.
+		//
+		// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
+		if ( 'ArrowFunctionExpression' === node.type && node.expression ) {
+			return node.body;
+		}
+
 		for ( i = 0; i < node.body.body.length; i++ ) {
 			bodyNode = node.body.body[ i ];
 			if ( 'ReturnStatement' === bodyNode.type ) {
@@ -119,6 +128,10 @@ var rule = module.exports = function( context ) {
 		element = node.parent.parent;
 
 		switch ( element.parent.type ) {
+			case 'ArrowFunctionExpression':
+				isElementReturnArg = element.parent.expression;
+				break;
+
 			case 'ReturnStatement':
 				isElementReturnArg = true;
 				break;
@@ -154,9 +167,7 @@ var rule = module.exports = function( context ) {
 
 				// If inside function expression, check that the name of the
 				// property is "render" (React.createClass or Component class)
-				// and that it is the return value of that function
-				if ( isRenderFunction( parent ) && ( isElementReturnArg ||
-						isSameIdentifier( elementAssignedIdentifier, getFunctionReturnValue( parent ) ) ) ) {
+				if ( isRenderFunction( parent ) ) {
 					isRoot = true;
 				}
 
@@ -176,6 +187,13 @@ var rule = module.exports = function( context ) {
 								isModuleExportNode( parent.parent.parent ) ) {
 							isRoot = true;
 						}
+				}
+
+				// If we suspect the element is the root, confirm that it's the
+				// return value of the function
+				if ( isRoot && ! isElementReturnArg &&
+						! isSameIdentifier( elementAssignedIdentifier, getFunctionReturnValue( parent ) ) ) {
+					isRoot = false;
 				}
 			}
 

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -86,16 +86,48 @@ var rule = module.exports = function( context ) {
 		].indexOf( node.type );
 	}
 
+	function getFunctionReturnValue( node ) {
+		var i, bodyNode;
+		for ( i = 0; i < node.body.body.length; i++ ) {
+			bodyNode = node.body.body[ i ];
+			if ( 'ReturnStatement' === bodyNode.type ) {
+				return bodyNode.argument;
+			}
+		}
+	}
+
+	function isSameIdentifier( nodeA, nodeB ) {
+		if ( ! nodeA || ! nodeB ) {
+			return false;
+		}
+
+		if ( 'Identifier' !== nodeA.type || 'Identifier' !== nodeB.type ) {
+			return false;
+		}
+
+		return nodeA.name === nodeB.name;
+	}
+
 	function isRootRenderedElement( node, filename ) {
-		var element, isReturnArg, parent, functionExpression, functionName,
-			isRoot;
+		var element, isElementReturnArg, elementAssignedIdentifier, parent,
+			functionExpression, functionName, isRoot;
 
 		if ( ! REGEXP_INDEX_PATH.test( filename ) ) {
 			return false;
 		}
 
 		element = node.parent.parent;
-		isReturnArg = 'ReturnStatement' === element.parent.type;
+
+		switch ( element.parent.type ) {
+			case 'ReturnStatement':
+				isElementReturnArg = true;
+				break;
+
+			case 'VariableDeclarator':
+				elementAssignedIdentifier = element.parent.id;
+				break;
+		}
+
 		parent = element;
 
 		do {
@@ -123,7 +155,8 @@ var rule = module.exports = function( context ) {
 				// If inside function expression, check that the name of the
 				// property is "render" (React.createClass or Component class)
 				// and that it is the return value of that function
-				if ( isRenderFunction( parent ) && isReturnArg ) {
+				if ( isRenderFunction( parent ) && ( isElementReturnArg ||
+						isSameIdentifier( elementAssignedIdentifier, getFunctionReturnValue( parent ) ) ) ) {
 					isRoot = true;
 				}
 

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -87,12 +87,16 @@ var rule = module.exports = function( context ) {
 	}
 
 	function isRootRenderedElement( node, filename ) {
-		var parent = node.parent.parent,
-			functionExpression, functionName, isRoot;
+		var element, isReturnArg, parent, functionExpression, functionName,
+			isRoot;
 
 		if ( ! REGEXP_INDEX_PATH.test( filename ) ) {
 			return false;
 		}
+
+		element = node.parent.parent;
+		isReturnArg = 'ReturnStatement' === element.parent.type;
+		parent = element;
 
 		do {
 			parent = parent.parent;
@@ -118,7 +122,8 @@ var rule = module.exports = function( context ) {
 
 				// If inside function expression, check that the name of the
 				// property is "render" (React.createClass or Component class)
-				if ( isRenderFunction( parent ) ) {
+				// and that it is the return value of that function
+				if ( isRenderFunction( parent ) && isReturnArg ) {
 					isRoot = true;
 				}
 

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -68,7 +68,18 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js'
 		},
 		{
+			code: 'export default function() { const child = <div className="foo__child" />; return <Foo className="foo">{ child }</Foo>; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
 			code: 'export default () => <Foo className="foo" />;',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default () => { return <Foo className="foo" />; }',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js'
@@ -231,6 +242,14 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			} ]
 		},
 		{
+			code: 'export default function() { const child = <div className="foo" />; return <Foo className="foo">{ child }</Foo>; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
+			} ]
+		},
+		{
 			code: 'export default function() { return <Foo className="quux foobar" />; }',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',
@@ -240,6 +259,15 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 		},
 		{
 			code: 'export default () => <Foo className="foobar" />;',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_ERROR
+			} ]
+		},
+		{
+			code: 'export default () => { return <Foo className="foobar" />; }',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -58,6 +58,11 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js'
 		},
 		{
+			code: 'export default function() { const foo = <Foo className="foo" />; return foo; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
 			code: 'export default function() { return <Foo className="quux foo" />; }',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js'
@@ -116,6 +121,11 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 		},
 		{
 			code: 'export default React.createClass( { render: function() { return <Foo className="foo" />; } } );',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default React.createClass( { render: function() { const foo = <Foo className="foo" />; return foo; } } );',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js'
 		},
@@ -213,6 +223,14 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			} ]
 		},
 		{
+			code: 'export default function() { const foo = <Foo className="foobar" />; return foo; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_ERROR
+			} ]
+		},
+		{
 			code: 'export default function() { return <Foo className="quux foobar" />; }',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',
@@ -302,6 +320,14 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 		},
 		{
 			code: 'export default React.createClass( { render: function() { return <Foo className="foobar" />; } } );',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_ERROR
+			} ]
+		},
+		{
+			code: 'export default React.createClass( { render: function() { const foo = <Foo className="foobar" />; return foo; } } );',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',
 			errors: [ {

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -120,7 +120,18 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			filename: '/tmp/foo/index.js'
 		},
 		{
+			code: 'export default React.createClass( { render: function() { return ( <Foo className="foo" /> ); } } );',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
 			code: 'export default React.createClass( { render() { return <Foo className="foo"><div className="foo__child" /></Foo>; } } );',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js'
+		},
+		{
+			code: 'export default React.createClass( { render() { const child = <div className="foo__child" />; return <Foo className="foo">{ child }</Foo>; } } );',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js'
@@ -298,7 +309,24 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			} ]
 		},
 		{
+			code: 'export default React.createClass( { render: function() { return ( <Foo className="foobar" /> ); } } );',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_ERROR
+			} ]
+		},
+		{
 			code: 'export default React.createClass( { render() { return <Foo className="foo"><div className="foobar__child" /></Foo>; } } );',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
+			} ]
+		},
+		{
+			code: 'export default React.createClass( { render() { const child = <div className="foo" />; return <Foo className="foo">{ child }</Foo>; } } );',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',


### PR DESCRIPTION
Fixes #19 

This pull request seeks to resolve a false positive when assigning an element to a variable in a component's `render` function which is in-fact not the root element, while still allowing a true root element to be assigned to a variable before being returned by the function.

**Testing instructions:**

Verify Mocha tests pass:

```
npm test
```

You can verify ESLint behavior by symlinking the package. First clone this repository locally. Then, in your Terminal, enter `npm ln` from the repository directory. In the project consuming `eslint-plugin-wpcalypso`, run `npm ln eslint-plugin-wpcalypso`.

/cc @stuwest @Copons
