### PR TITLE
Upgrade ESLint to 3.x latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #### v2.0.0 (---)
 
-- Breaking: Required Node version increased to >=0.12.0
+- Breaking: Required Node version increased from >=0.10.x to >=4.x ([see ESLint 3.0.0 migration guide](http://eslint.org/docs/user-guide/migrating-to-3.0.0))
 - Fix: `jsx-classname-namespace` can accurately validate elements assigned to variables within render ([#21](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/21))
 - Fix: `npm test` is now run synchronously so it exits with a non-zero code on failure
 - Fix: Replace ES2015 variable (`let`) declarations to accommodate older Node versions
@@ -8,6 +8,7 @@
 - Fix: jsx-classname-namespace will now correctly identify index components in Windows environments ([#18](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/18))
 - General: Add `files` to `package.json` to omit files relevant only for development
 - General: Use shared configuration for linting (yo dawg, i herd you like ESLint rules...) ([#22](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/22))
+- General: Updated ESLint from 2.x to 3.x
 
 #### v1.4.1 (August 12, 2016)
 

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.1.0",
-    "eslint": "^2.13.1",
+    "eslint": "^3.3.1",
     "eslint-config-wpcalypso": "^0.2.0",
     "eslint-plugin-wpcalypso": "file:.",
     "mocha": "^3.0.2"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4"
   },
   "license": "GPL-2.0+"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "babel-eslint": "^6.1.0",
     "eslint": "^3.3.1",
-    "eslint-config-wpcalypso": "^0.2.0",
+    "eslint-config-wpcalypso": "^0.3.0",
     "eslint-plugin-wpcalypso": "file:.",
     "mocha": "^3.0.2"
   },


### PR DESCRIPTION
Tests will fail due to `eslint-config-wpcalypso` failing peer dependency on the ESLint upgrade. We'll need to coordinate a release of a `0.3.0` shared configuration simultaneously updating ESLint and `eslint-plugin-wpcalypso` to latest (latest of the latter being `2.0.0` despite not yet being released).
