### PR TITLE
i18n: Disallow filler text to be translated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v2.x (unreleased)
+
+- New rule: [`i18n-no-filler-text`](docs/rules/i18n-no-filler-text.md)
+
 #### v2.0.0 (August 24, 2016)
 
 - Breaking: Required Node version increased from >=0.10.x to >=4.x ([see ESLint 3.0.0 migration guide](http://eslint.org/docs/user-guide/migrating-to-3.0.0))

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then configure the rules you want to use under the rules section.
 - [`i18n-ellipsis`](docs/rules/i18n-ellipsis.md): Disallow using three dots in translate strings
 - [`i18n-mismatched-placeholders`](docs/rules/i18n-mismatched-placeholders.md): Ensure placeholder counts match between singular and plural strings
 - [`i18n-named-placeholders`](docs/rules/i18n-named-placeholders.md): Disallow multiple unnamed placeholders
+- [`i18n-no-filler-text`](docs/rules/i18n-no-filler-text.md): Disallow strings with filler text
 - [`i18n-no-newlines`](docs/rules/i18n-no-newlines.md): Disallow newlines in translatable strings
 - [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md): Disallow strings which include only placeholders
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings

--- a/docs/rules/i18n-no-filler-text.md
+++ b/docs/rules/i18n-no-filler-text.md
@@ -1,0 +1,21 @@
+# Disallow filler text in translatable strings
+
+Filler text should not be passed through the translate function as this might trigger unwanted submission of translation of the text. 
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+translate( "Lorem ipsum dolor amet" );
+translate( "Bacon ipsum dolor" );
+translate( "bla bla" );
+translate( "This is a sample text blablabla" );
+```
+
+The following patterns are not warnings:
+
+```js
+translate( 'Hey dipsum!' );
+translate( 'Ablation is removal of material from the surface of an object.' );
+```

--- a/lib/rules/i18n-no-filler-text.js
+++ b/lib/rules/i18n-no-filler-text.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Disallow filler text in translate strings
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+var getCallee = require( '../util/get-callee' ),
+	getTextContentFromNode = require( '../util/get-text-content-from-node' );
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var rule = module.exports = function( context ) {
+	var fillerRegExp = [
+		new RegExp( /\blorem ipsum\b/, 'i' ),
+		new RegExp( /\bipsum dolor\b/, 'i' ),
+		new RegExp( /\bdolor amt\b/, 'i' ),
+		new RegExp( /\b(bla)+\b/, 'i' ),
+	];
+
+	return {
+		CallExpression: function( node ) {
+			var i;
+			if ( 'translate' !== getCallee( node ).name ) {
+				return;
+			}
+
+			node.arguments.forEach( function( arg ) {
+				var argumentString = getTextContentFromNode( arg );
+
+				for ( i = 0; i < fillerRegExp.length; i++ ) {
+					if ( argumentString && fillerRegExp[ i ].test( argumentString ) ) {
+						context.report( node.arguments[ 0 ], rule.ERROR_MESSAGE );
+						break;
+					}
+				}
+			} );
+		}
+	};
+};
+
+rule.ERROR_MESSAGE = 'Use of filler text';
+
+rule.schema = [];

--- a/tests/lib/rules/i18n-no-filler-text.js
+++ b/tests/lib/rules/i18n-no-filler-text.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Disallow strings which include only placeholders
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-filler-text' ),
+	config = { env: { es6: true } },  // support for string templates
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( config ) ).run( 'i18n-no-filler-text', rule, {
+	valid: [
+		{
+			code: 'translate( \'Hey dipsum!\' );'
+		},
+		{
+			code: 'translate( \'Ablation is removal of material from the surface of an object.\' );'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'translate( \'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( `Bacon ipsum dolor amet sirloin bresaola leberkas, strip steak hamburger short ribs beef pork. Tenderloin salami sausage tongue capicola. Hamburger tenderloin prosciutto venison pork loin, bresaola tri-tip shank.` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Lorem ipsum\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'Lorem ipsum dolor sit amet\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'bla bla\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		},
+		{
+			code: 'translate( \'This is a sample text blablabla\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE
+			} ]
+		}
+	]
+} );


### PR DESCRIPTION
We should prevent filler text from being translated as we might accidentially send it for translation. Example texts include:

```
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
```

```
Bacon ipsum dolor amet sirloin bresaola leberkas, strip steak hamburger short ribs beef pork.
```

```
blabla
```

Of course we cannot catch all filler texts but only the obvious ones.
