### PR TITLE
jsx-classname-namespace: Validate non-root as containing only expected underscores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v?.?.? (---)
+
+- Fix: `jsx-classname-namespace` will not allow underscores except as separator after namespace
+
 #### v2.0.0 (August 24, 2016)
 
 - Breaking: Required Node version increased from >=0.10.x to >=4.x ([see ESLint 3.0.0 migration guide](http://eslint.org/docs/user-guide/migrating-to-3.0.0))

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -262,7 +262,7 @@ var rule = module.exports = function( context ) {
 
 			classNames = rawClassName.value.split( ' ' );
 			namespace = path.basename( path.dirname( filename ) );
-			prefixPattern = new RegExp( `^${ namespace }__[a-z0-9]+$` );
+			prefixPattern = new RegExp( `^${ namespace }__[a-z0-9-]+$` );
 
 			isError = ! classNames.some( function( className ) {
 				if ( isRoot ) {

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -235,8 +235,8 @@ var rule = module.exports = function( context ) {
 
 	return {
 		JSXAttribute: function( node ) {
-			var rawClassName, filename, isRoot, classNames, namespace, prefix,
-				isError, expected;
+			var rawClassName, filename, isRoot, classNames, namespace,
+				prefixPattern, isError, expected;
 
 			if ( 'className' !== node.name.name ) {
 				return;
@@ -262,7 +262,7 @@ var rule = module.exports = function( context ) {
 
 			classNames = rawClassName.value.split( ' ' );
 			namespace = path.basename( path.dirname( filename ) );
-			prefix = namespace + '__';
+			prefixPattern = new RegExp( `^${ namespace }__[a-z0-9]+$` );
 
 			isError = ! classNames.some( function( className ) {
 				if ( isRoot ) {
@@ -271,10 +271,7 @@ var rule = module.exports = function( context ) {
 
 				// Non-root node should have class name starting with but not
 				// equal to namespace prefix
-				return (
-					0 === className.indexOf( prefix ) &&
-					className !== prefix
-				);
+				return prefixPattern.test( className );
 			} );
 
 			if ( ! isError ) {

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -221,6 +221,11 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			code: 'export default function() { return <div className="foo__child" />; }',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/foo-child.js'
+		},
+		{
+			code: 'export default function() { return <div className="foo__child-example2" />; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo-child.js'
 		}
 	],
 

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -465,6 +465,15 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			errors: [ {
 				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]
+		},
+		{
+			code: 'export default function() { return <Foo className="foo"><div className="foo__child__example" /></Foo>; }',
+			env: { es6: true },
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
+			} ]
 		}
 	]
 } );


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/pull/7866/files/1cb3beb74615810026453bb6204a051489fad604#r77802780

This pull request seeks to resolve an issue where the following class name could be considered valid for a non-root element, when run against the `jsx-classname-namespace` rule:

`foo__child__example`

Previously we were only verifying that the non-root element class name started with and was not equal to the folder name plus two underscores. We now test the rest of the class name to ensure that it consists only of lowercase letters, numbers, and dashes. 

While it is technically possible for CSS class name selectors to contain other characters ([reference](https://www.w3.org/TR/CSS21/syndata.html#characters)), the included pattern assumes we want to enforce `[a-z0-9-]` as the only valid characters after the namespaced prefix.

cc @mtias 
