### PR TITLE
i18n-no-this-translate: Add i18n-no-this-translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Then configure the rules you want to use under the rules section.
 - [`i18n-named-placeholders`](docs/rules/i18n-named-placeholders.md): Disallow multiple unnamed placeholders
 - [`i18n-no-collapsible-whitespace`](docs/rules/i18n-no-collapsible-whitespace.md): Disallow collapsible whitespace in translatable strings
 - [`i18n-no-placeholders-only`](docs/rules/i18n-no-placeholders-only.md): Disallow strings which include only placeholders
+- [`i18n-no-this-translate`](docs/rules/i18n-no-this-translate.md): Disallow this.translate()
 - [`i18n-no-variables`](docs/rules/i18n-no-variables.md): Disallow variables as translate strings
 - [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md): Ensure JSX className adheres to CSS namespace guidelines
 - [`jsx-gridicon-size`](docs/rules/jsx-gridicon-size.md): Enforce recommended Gridicon size attributes

--- a/docs/rules/i18n-no-this-translate.md
+++ b/docs/rules/i18n-no-this-translate.md
@@ -1,0 +1,31 @@
+# Disallow this.translate()
+Disallows the usage of `this.translate()` in favor of the high order component `localize()` from `i18n-calypso` repository.
+
+## Rule Details
+
+This rules aims to prevent the usage of `this.translate` that uses the mixin approach which makes the components harder to test.
+The following is considered a warning:
+```js
+const MyComponent = React.createClass( {
+	render() {
+		return this.translate( 'Hello World' );
+	}
+} );
+```
+
+The following patterns are not warnings:
+
+```js
+import i18n from 'i18n-calypso';
+i18n.translate('Hello World');
+```
+
+```js
+import { localize } from 'i18n-calypso';
+const MyComponent = React.createClass( {
+	render() {
+		return this.props.translate( 'Hello World' );
+	}
+} );
+export default localize( MyComponent );
+```

--- a/lib/rules/i18n-no-this-translate.js
+++ b/lib/rules/i18n-no-this-translate.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Disallow the use of this.translate
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE = 'Use localize( ReactComponent ) instead of this.translate';
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Disallow the use of this.translate',
+			category: 'Deprecation',
+			recommended: true
+		},
+		schema: []
+	},
+	create: function( context ) {
+		return {
+			CallExpression: function( node ) {
+				if ( node.callee.type === 'MemberExpression' &&
+					node.callee.object.type === 'ThisExpression' &&
+					node.callee.property.name === 'translate' ) {
+					context.report( node, ERROR_MESSAGE );
+				}
+			}
+		};
+	}
+};

--- a/tests/lib/rules/i18n-no-this-translate.js
+++ b/tests/lib/rules/i18n-no-this-translate.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Disallow the use of this.translate
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require( '../../../lib/rules/i18n-no-this-translate' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester() ).run( 'i18n-no-this-translate', rule, {
+	valid: [
+		'i18n.translate(\'hello\')',
+		'translate(\'hello\')',
+		'this.props.translate(\'hello\')'
+	],
+
+	invalid: [
+		{
+			code: 'this.translate(\'hello\')',
+			errors: [ {
+				message: 'Use localize( ReactComponent ) instead of this.translate'
+			} ]
+		}
+	]
+} );


### PR DESCRIPTION
This PR adds a `i18n-no-this-translate` rule in favor of `i18n.localize`. 

Since it's been making testing harder and the community is moving away from mixins, we should try to reduce the usage of the mixin.

So this,

``` js
export default React.createClass( {
  render() {
    return this.translate( "Hello world" );  
  }  
} );
```

Should become:

``` js
import { localize } from 'i18n-calypso';

const MyComponent = React.createClass( {
  render() {
    return this.props.translate( "Hello world" );  
  }  
} );
export default localize( MyComponent );
```

/cc: @aduth @mtias 
