### PR TITLE
Add rule for enforcing import docblocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### v?.?.? (---)
 
+- New rule: [`import-docblock`](docs/rules/import-docblock.md)
 - Fix: `jsx-classname-namespace` will not allow underscores except as separator after namespace
 
 #### v2.0.0 (August 24, 2016)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Then configure the rules you want to use under the rules section.
 - [`jsx-classname-namespace`](docs/rules/jsx-classname-namespace.md): Ensure JSX className adheres to CSS namespace guidelines
 - [`jsx-gridicon-size`](docs/rules/jsx-gridicon-size.md): Enforce recommended Gridicon size attributes
 - [`no-lodash-import`](docs/rules/no-lodash-import.md): Disallow importing from the root Lodash module
+- [`import-docblock`](docs/rules/import-docblock.md): Enforce external, internal dependencies docblocks
 
 ## License
 

--- a/docs/rules/import-docblock.md
+++ b/docs/rules/import-docblock.md
@@ -1,0 +1,20 @@
+# Enforce external, internal dependencies docblocks
+
+When importing modules, you should distinguish external dependencies from internal dependencies using DocBlock multi-line comments. Because Calypso modifies the `NODE_PATH` to allow importing modules directly from the root `client/` directory, it can be otherwise unclear whether an imported module is an internal or an external dependency.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+import React from 'react';
+```
+
+The following patterns are not warnings:
+
+```js
+/**
+ * External dependencies
+ */
+import React from 'react';
+```

--- a/lib/rules/import-docblock.js
+++ b/lib/rules/import-docblock.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Enforce external, internal dependencies docblocks
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE = 'Missing external, internal dependencies docblocks';
+const RX_DOCBLOCK = /\/\*\*\n \* (Ex|In)ternal dependencies\n \*\//;
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Enforce external, internal dependencies docblocks',
+			category: 'Stylistic Issues'
+		}
+	},
+	create( context ) {
+		let hasIssue = false;
+
+		return {
+			ImportDeclaration() {
+				hasIssue = hasIssue || ! RX_DOCBLOCK.test( context.getSourceCode().text );
+			},
+			'Program:exit'( node ) {
+				if ( hasIssue ) {
+					context.report( node, ERROR_MESSAGE );
+				}
+			}
+		};
+	}
+};

--- a/tests/lib/rules/import-docblock.js
+++ b/tests/lib/rules/import-docblock.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Enforce external, internal dependencies docblocks
+ * @author Automattic
+ * @copyright 2016 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require( '../../../lib/rules/import-docblock' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module'
+	}
+} ) ).run( 'import-docblock', rule, {
+	valid: [
+		{
+			code:
+`/**
+ * External dependencies
+ */
+import eslint from \'eslint\';`
+		}
+	],
+
+	invalid: [
+		{
+			code: 'import eslint from \'eslint\';',
+			errors: [ {
+				message: 'Missing external, internal dependencies docblocks'
+			} ]
+		}
+	]
+} );


### PR DESCRIPTION
This pull request seeks to introduce a new rule, `import-docblock`, intended to enforce multi-line comment docblocks distinguishing import types in a script. See included [rule documentation](https://github.com/Automattic/eslint-plugin-wpcalypso/blob/a47f79a68c49e29e2126be4d903a190a7213bc66/docs/rules/import-docblock.md) for more information.

**Testing Instructions:**

Verify that tests pass:

```
npm test
```
