### PR TITLE
Fix(jsx-classname-namespace): Accept root components in `main.jsx` files

### DIFF
--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -16,7 +16,7 @@ var path = require( 'path' );
 // Constants
 //------------------------------------------------------------------------------
 
-var REGEXP_INDEX_PATH = /(\\|\/)index\.jsx?$/;
+var REGEXP_INDEX_PATH = /(\\|\/)(index|main)\.jsx?$/;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -13,19 +13,11 @@
 var path = require( 'path' );
 
 //------------------------------------------------------------------------------
-// Constants
-//------------------------------------------------------------------------------
-
-const DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx' ];
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 var rule = module.exports = function( context ) {
-	const rootFiles = ( context.options.length === 1 )
-		? context.options[ 0 ].rootFiles
-		: DEFAULT_ROOT_FILES;
+	const rootFiles = ( context.options[ 0 ] || {} ).rootFiles || rule.DEFAULT_ROOT_FILES;
 
 	function isModuleExportNode( node ) {
 		return (
@@ -302,6 +294,7 @@ var rule = module.exports = function( context ) {
 };
 
 rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines (expected {{expected}})';
+rule.DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx' ];
 
 rule.schema = [
 	{

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -263,7 +263,7 @@ var rule = module.exports = function( context ) {
 			prefixPattern = new RegExp( `^${ namespace }__[a-z0-9-]+$` );
 
 			isError = ! classNames.some( function( className ) {
-				if ( isRootElement ) {
+				if ( isRootElement && isRootFile ) {
 					return className === namespace;
 				}
 
@@ -272,17 +272,17 @@ var rule = module.exports = function( context ) {
 				return prefixPattern.test( className );
 			} );
 
-			if ( isRootFile && ! isError ) {
+			if ( ! isError ) {
 				return;
 			}
 
-			if ( ! isRootFile && ! isError ) {
-				expected = `root component to be in one of ${ rootFiles.join( ', ' ) }`;
-			} else {
-				expected = namespace;
-				if ( ! isRootElement ) {
-					expected = `${ namespace }__ prefix`;
-				}
+			expected = namespace;
+			if ( ! ( isRootElement && isRootFile ) ) {
+				expected += '__ prefix';
+			}
+
+			if ( isRootElement && ! isRootFile ) {
+				expected += ` or to be in one of ${ rootFiles.join( ', ' ) }`;
 			}
 
 			context.report( {

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -114,7 +114,8 @@ var rule = module.exports = function( context ) {
 	}
 
 	function isFolderRootFile( filename ) {
-		return rootFiles.indexOf( filename ) !== -1;
+		const stripedFileName = filename.substr( filename.lastIndexOf( '/' ) + 1 );
+		return rootFiles.indexOf( stripedFileName ) !== -1;
 	}
 
 	function isRootElementInFile( node ) {

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -16,13 +16,17 @@ var path = require( 'path' );
 // Constants
 //------------------------------------------------------------------------------
 
-var REGEXP_INDEX_PATH = /(\\|\/)(index|main)\.jsx?$/;
+const DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx' ];
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 var rule = module.exports = function( context ) {
+	const rootFiles = ( context.options.length === 1 )
+		? context.options[ 0 ].rootFiles
+		: DEFAULT_ROOT_FILES;
+
 	function isModuleExportNode( node ) {
 		return (
 			'ExpressionStatement' === node.type &&
@@ -118,7 +122,7 @@ var rule = module.exports = function( context ) {
 	}
 
 	function isFolderRootFile( filename ) {
-		return REGEXP_INDEX_PATH.test( filename );
+		return rootFiles.indexOf( filename ) !== -1;
 	}
 
 	function isRootElementInFile( node ) {
@@ -280,7 +284,7 @@ var rule = module.exports = function( context ) {
 			}
 
 			if ( ! isRootFile && ! isError ) {
-				expected = 'root component in file index.jsx or main.jsx';
+				expected = `root component to be in one of ${ rootFiles.join( ', ' ) }`;
 			} else {
 				expected = namespace;
 				if ( ! isRootElement ) {
@@ -299,4 +303,17 @@ var rule = module.exports = function( context ) {
 
 rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines (expected {{expected}})';
 
-rule.schema = [];
+rule.schema = [
+	{
+		type: 'object',
+		properties: {
+			rootFiles: {
+				type: 'array',
+				items: {
+					type: 'string',
+				},
+			},
+		},
+		additionalProperties: false,
+	},
+];

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -114,8 +114,7 @@ var rule = module.exports = function( context ) {
 	}
 
 	function isFolderRootFile( filename ) {
-		const stripedFileName = filename.substr( filename.lastIndexOf( '/' ) + 1 );
-		return rootFiles.indexOf( stripedFileName ) !== -1;
+		return rootFiles.indexOf( path.basename( filename ) ) !== -1;
 	}
 
 	function isRootElementInFile( node ) {

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -117,13 +117,13 @@ var rule = module.exports = function( context ) {
 		return nodeA.name === nodeB.name;
 	}
 
-	function isRootRenderedElement( node, filename ) {
+	function isFolderRootFile( filename ) {
+		return REGEXP_INDEX_PATH.test( filename );
+	}
+
+	function isRootElementInFile( node ) {
 		var element, isElementReturnArg, elementAssignedIdentifier, parent,
 			functionExpression, functionName, isRoot;
-
-		if ( ! REGEXP_INDEX_PATH.test( filename ) ) {
-			return false;
-		}
 
 		element = node.parent.parent;
 
@@ -235,8 +235,8 @@ var rule = module.exports = function( context ) {
 
 	return {
 		JSXAttribute: function( node ) {
-			var rawClassName, filename, isRoot, classNames, namespace,
-				prefixPattern, isError, expected;
+			var rawClassName, filename, isRootElement, isRootFile, classNames,
+				namespace, prefixPattern, isError, expected;
 
 			if ( 'className' !== node.name.name ) {
 				return;
@@ -253,10 +253,11 @@ var rule = module.exports = function( context ) {
 			}
 
 			filename = context.getFilename();
-			isRoot = isRootRenderedElement( node, filename );
+			isRootFile = isFolderRootFile( filename );
+			isRootElement = isRootElementInFile( node );
 
 			// `null` return value indicates intent to abort validation
-			if ( null === isRoot ) {
+			if ( null === isRootElement ) {
 				return;
 			}
 
@@ -265,7 +266,7 @@ var rule = module.exports = function( context ) {
 			prefixPattern = new RegExp( `^${ namespace }__[a-z0-9-]+$` );
 
 			isError = ! classNames.some( function( className ) {
-				if ( isRoot ) {
+				if ( isRootElement ) {
 					return className === namespace;
 				}
 
@@ -274,21 +275,23 @@ var rule = module.exports = function( context ) {
 				return prefixPattern.test( className );
 			} );
 
-			if ( ! isError ) {
+			if ( isRootFile && ! isError ) {
 				return;
 			}
 
-			expected = namespace;
-			if ( ! isRoot ) {
-				expected += '__ prefix';
+			if ( ! isRootFile && ! isError ) {
+				expected = 'root component in file index.jsx or main.jsx';
+			} else {
+				expected = namespace;
+				if ( ! isRootElement ) {
+					expected = `${ namespace }__ prefix`;
+				}
 			}
 
 			context.report( {
 				node: node,
 				message: rule.ERROR_MESSAGE,
-				data: {
-					expected: expected
-				}
+				data: { expected },
 			} );
 		}
 	};

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -303,6 +303,7 @@ rule.schema = [
 		properties: {
 			rootFiles: {
 				type: 'array',
+				minItems: 1,
 				items: {
 					type: 'string',
 				},

--- a/lib/rules/jsx-classname-namespace.js
+++ b/lib/rules/jsx-classname-namespace.js
@@ -282,7 +282,7 @@ var rule = module.exports = function( context ) {
 			}
 
 			if ( isRootElement && ! isRootFile ) {
-				expected += ` or to be in one of ${ rootFiles.join( ', ' ) }`;
+				expected += ` or to be in ${ rootFiles.length > 1 ? 'one of ' : '' }${ rootFiles.join( ', ' ) }`;
 			}
 
 			context.report( {

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -203,6 +203,12 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			code: 'export default function() { return <div className="foo__child-example2" />; }',
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/foo-child.js'
+		},
+		{
+			code: 'export default function() { return <div className="foo"></div>; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo.js',
+			options: [ { rootFiles: [ 'foo.js' ] } ],
 		}
 	],
 
@@ -436,7 +442,10 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/foo-child.js',
 			errors: [ {
-				message: EXPECTED_FOO_PREFIX_ERROR
+				message: formatMessage(
+					rule.ERROR_MESSAGE,
+					{ expected: `foo__ prefix or to be in one of ${ rule.DEFAULT_ROOT_FILES.join( ', ' ) }` }
+				)
 			} ]
 		},
 		{
@@ -453,6 +462,14 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
 			filename: '/tmp/foo/index.js',
+			errors: [ {
+				message: EXPECTED_FOO_PREFIX_ERROR
+			} ]
+		},
+		{
+			code: 'export default function() { return <div><div className="foo" /></div>; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo-child.js',
 			errors: [ {
 				message: EXPECTED_FOO_PREFIX_ERROR
 			} ]

--- a/tests/lib/rules/jsx-classname-namespace.js
+++ b/tests/lib/rules/jsx-classname-namespace.js
@@ -449,6 +449,18 @@ EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo_
 			} ]
 		},
 		{
+			code: 'export default function() { return <div className="foo" />; }',
+			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },
+			filename: '/tmp/foo/foo-child.js',
+			options: [ { rootFiles: [ 'one.js' ] } ],
+			errors: [ {
+				message: formatMessage(
+					rule.ERROR_MESSAGE,
+					{ expected: 'foo__ prefix or to be in one.js' }
+				)
+			} ]
+		},
+		{
 			code: 'export default function() { return <Foo className="foo"><div className="foo__" /></Foo>; }',
 			env: { es6: true },
 			parserOptions: { ecmaFeatures: { jsx: true }, sourceType: 'module' },


### PR DESCRIPTION
In the [devdocs's Hello World](https://wpcalypso.wordpress.com/devdocs/docs/guide/hello-world.md), we are currently breaking this ESLint rule, because the view-component is in a `main.jsx` file (to not conflict with `index.js` where we have the routing setup). A couple of others components around the calypso codebase also use `main.jsx` (37).

The main (limited) risk would be with directories containing both `index.jsx` and `main.jsx`. The only case currently in the calypso codebase is `/me/happychat`:

$ find . -type d -exec test -e {}/index.jsx -a -e {}/main.jsx \; -print
./me/happychat

By looking at the code, `index.jsx` is a controller-like calling `reactDom`, nothing fancy in it, making `main.jsx` the true container for a "root" component.