### PR TITLE
Add URL to i18n-no-this-translate error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v3.1.1 (2017-04-08)
+
+- Fix: added a documentation link to the `i18n-no-this-translate` error message
+
 #### v3.1.0 (2017-01-26)
 
  - New rule: [`post-message-no-wildcard-targets`](docs/rules/post-message-no-wildcard-targets.md)

--- a/lib/rules/i18n-no-this-translate.js
+++ b/lib/rules/i18n-no-this-translate.js
@@ -10,7 +10,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Use localize( ReactComponent ) instead of this.translate';
+const ERROR_MESSAGE = 'Use localize( ReactComponent ) instead of this.translate. See https://git.io/vSwRi';
 
 module.exports = {
 	meta: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/i18n-no-this-translate.js
+++ b/tests/lib/rules/i18n-no-this-translate.js
@@ -28,7 +28,7 @@ var rule = require( '../../../lib/rules/i18n-no-this-translate' ),
 		{
 			code: 'this.translate(\'hello\')',
 			errors: [ {
-				message: 'Use localize( ReactComponent ) instead of this.translate'
+				message: 'Use localize( ReactComponent ) instead of this.translate. See https://git.io/vSwRi'
 			} ]
 		}
 	]


### PR DESCRIPTION
This way developers will get a lot more details about how to fix it.

The link goes to https://github.com/Automattic/eslint-plugin-wpcalypso/blob/master/docs/rules/i18n-no-this-translate.md and has been shortened through https://git.io.

The link to `master` may be a bit fragile, but let’s not make this more complicated unless we hit problems.