### PR TITLE
Add docs for jsx-classname-namespace options

### DIFF
--- a/docs/rules/jsx-classname-namespace.md
+++ b/docs/rules/jsx-classname-namespace.md
@@ -51,7 +51,7 @@ For example, you can allow `index.jsx` and `main.jsx`:
 
 ```json
 {
-    "jsx-classname-namespace": [
+	"jsx-classname-namespace": [
 		"error",
 		{
 			"rootFiles": [ "index.jsx", "main.jsx" ]

--- a/docs/rules/jsx-classname-namespace.md
+++ b/docs/rules/jsx-classname-namespace.md
@@ -41,3 +41,41 @@ export default function() {
 	);
 }
 ```
+
+## Options
+
+This rule accepts an object as its first option:
+* `"rootFiles"` (default: `[ index.js, index.jsx ]`) array of filenames allowed to contain root component in each folder.
+
+For example, you can allow `index.jsx` and `main.jsx`:
+
+```json
+{
+    "jsx-classname-namespace": [
+		"error",
+		{
+			"rootFiles": [ "index.jsx", "main.jsx" ]
+		}
+	]
+}
+```
+
+Examples of **correct** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
+
+```js
+/*eslint jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]*/
+// client/sample-component/foo.js
+export default function() {
+	return <div className="sample" />;
+}
+```
+
+Examples of **incorrect** code for this rule with `rootFiles` set to `[ 'foo.js' ]`: (watch the filename)
+
+```js
+/*eslint jsx-classname-namespace: [ "error", { rootFiles: [ 'foo.js' ] } ]*/
+// client/sample-component/index.js
+export default function() {
+	return <div className="sample" />;
+}
+```


### PR DESCRIPTION
Doc PR mentioned in #34 

I tried to follow the same construction as ESLint's main rules for describing options: [indent](https://raw.githubusercontent.com/eslint/eslint/master/docs/rules/indent.md) for instance