### PR TITLE
Add rule to disallow combineReducers imports from redux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### v3.3.0 (2017-05-25)
+
+- New Rule: [`import-no-redux-combine-reducers`](docs/rules/import-no-redux-combine-reducers.md)
+
 #### v3.2.0 (2017-04-11)
 
 - Updated: jsx-classname-namespace: New "rootFiles" option to specify files in which components are to be considered as root (defaults to "index.js", "index.jsx") ([#34](https://github.com/Automattic/eslint-plugin-wpcalypso/pull/34), thanks @bperson)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then configure the rules you want to use under the rules section.
 - [`jsx-gridicon-size`](docs/rules/jsx-gridicon-size.md): Enforce recommended Gridicon size attributes
 - [`import-docblock`](docs/rules/import-docblock.md): Enforce external, internal dependencies docblocks
 - [`post-message-no-wildcard-targets`](docs/rules/post-message-no-wildcard-targets.md): Disallow using the wildcard '*' in `postMessage`
+- [`import-no-redux-combine-reducers`](docs/rules/import-no-redux-combine-reducers.md): Disallow combineReducers import from redux
 
 ## License
 

--- a/docs/rules/import-no-redux-combine-reducers.md
+++ b/docs/rules/import-no-redux-combine-reducers.md
@@ -1,0 +1,24 @@
+# Always import combineReducers from 'state/utils'
+
+In Calypso we should always import `combineReducers` from `state/utils` instead of `redux`. Our reducing function handles
+persistence for us. If we use the default reducing function from redux, we may persist state accidentally.
+
+See also: [Opt-in to Persistence](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#opt-in-to-persistence--13542-)
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+import { combineReducers } from 'redux';
+```
+
+The following patterns are not warnings:
+
+```js
+import { combineReducers } from 'state/utils';
+```
+
+```js
+import { createStore } from 'redux';
+```

--- a/lib/rules/import-no-redux-combine-reducers.js
+++ b/lib/rules/import-no-redux-combine-reducers.js
@@ -23,10 +23,10 @@ module.exports = {
 		return {
 			ImportDeclaration( node ) {
 				if ( node.source.value === 'redux' ) {
-					const combineReducers = node.specifiers.filter(
+					const hasCombineReducersFromRedux = node.specifiers.some(
 						( specifier ) => ( specifier.imported.name === 'combineReducers' )
 					);
-					if ( combineReducers.length > 0 ) {
+					if ( hasCombineReducersFromRedux ) {
 						context.report( node, ERROR_MESSAGE );
 					}
 				}

--- a/lib/rules/import-no-redux-combine-reducers.js
+++ b/lib/rules/import-no-redux-combine-reducers.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Disallow combineReducers import from redux
+ * @author Automattic
+ * @copyright 2017 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const ERROR_MESSAGE = 'combineReducers should be imported from state/utils not redux';
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Disallow combineReducers import from redux',
+			category: 'Possible Errors'
+		}
+	},
+	create( context ) {
+		return {
+			ImportDeclaration( node ) {
+				if ( node.source.value === 'redux' ) {
+					const combineReducers = node.specifiers.filter(
+						( specifier ) => ( specifier.imported.name === 'combineReducers' )
+					);
+					if ( combineReducers.length > 0 ) {
+						context.report( node, ERROR_MESSAGE );
+					}
+				}
+			},
+		};
+	},
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-wpcalypso",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Custom ESLint rules for the WordPress.com Calypso project",
   "repository": {
     "type": "git",

--- a/tests/lib/rules/import-no-redux-combine-reducers.js
+++ b/tests/lib/rules/import-no-redux-combine-reducers.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Disallow combineReducers import from redux
+ * @author Automattic
+ * @copyright 2017 Automattic. All rights reserved.
+ * See LICENSE.md file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require( '../../../lib/rules/import-no-redux-combine-reducers' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( {
+	parserOptions: {
+		ecmaVersion: 6,
+		sourceType: 'module'
+	}
+} ) ).run( 'import-no-redux-combine-reducers', rule, {
+	valid: [
+		{
+			code: 'import { combineReducers } from \'state/utils\';'
+		},
+		{
+			code: 'import { combineReducers as bar } from \'state/utils\';'
+		},
+		{
+			code: 'import { createStore } from \'redux\';'
+		},
+	],
+
+	invalid: [
+		{
+			code: 'import { combineReducers } from \'redux\';',
+			errors: [ {
+				message: 'combineReducers should be imported from state/utils not redux'
+			} ]
+		},
+		{
+			code: 'import { createStore, combineReducers } from \'redux\';',
+			errors: [ {
+				message: 'combineReducers should be imported from state/utils not redux'
+			} ]
+		},
+		{
+			code: 'import { createStore, combineReducers as bar } from \'redux\';',
+			errors: [ {
+				message: 'combineReducers should be imported from state/utils not redux'
+			} ]
+		}
+	]
+} );


### PR DESCRIPTION
This adds a new eslint rule to disallow `combineReducers` imports from `redux`. This is a follow up to https://github.com/Automattic/wp-calypso/pull/14436 to avoid accidental imports

If these changes land, in Calypso, I'll add an exception for the one usage of `combineReducers` in `state/utils`.

### Testing Instructions
- `npm test`