### PR TITLE
Fix TypeError in i18n-named-placeholders when translate() has no arguments

### DIFF
--- a/lib/rules/i18n-named-placeholders.js
+++ b/lib/rules/i18n-named-placeholders.js
@@ -41,6 +41,12 @@ rule = module.exports = function( context ) {
 	return {
 		CallExpression: function( node ) {
 			var singular, plural;
+
+			// Done if no args are passed
+			if ( node.arguments.length === 0 ) {
+				return;
+			}
+
 			if ( 'translate' !== getCallee( node ).name ) {
 				return;
 			}

--- a/tests/lib/rules/i18n-named-placeholders.js
+++ b/tests/lib/rules/i18n-named-placeholders.js
@@ -21,6 +21,9 @@ var rule = require( '../../../lib/rules/i18n-named-placeholders' ),
 ( new RuleTester( config ) ).run( 'i18n-named-placeholders', rule, {
 	valid: [
 		{
+			code: 'translate( /* zero args */ );'
+		},
+		{
 			code: 'translate( \'Hello %s\' );'
 		},
 		{


### PR DESCRIPTION
When checking a `translate()` statement with no arguments, the `i18n-named-placeholders` rule crashes with `TypeError: Cannot read property 'type' of undefined`. It's accessing `node.arguments[ 0 ]` on an empty array.

Happened to me when Atom linter plugin checked a file where I was in the middle of typing a new `translate` statement.
