### PR TITLE
Correct i18n-ellipsis fix quotes

### DIFF
--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -58,7 +58,10 @@ var rule = module.exports = function( context ) {
 								);
 								return fixes;
 							}
-							return fixer.replaceText( arg, "'" + argumentString.replace( /\.\.\./g, '…' ) + "'" );
+							if ( arg.type === 'Literal' ) {
+								return fixer.replaceText( arg, replaceThreeDotsWithEllipsis( arg.raw ) );
+							}
+							return fixer.replaceText( arg, "'" + replaceThreeDotsWithEllipsis( argumentString ) + "'" );
 						},
 					} );
 				}

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -17,6 +17,14 @@ var getCallee = require( '../util/get-callee' ),
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function containsThreeDots( string ) {
+	return -1 !== string.indexOf( '...' );
+}
+
+function replaceThreeDotsWithEllipsis( string ) {
+	return string.replace( /\.\.\./g, '…' );
+}
+
 var rule = module.exports = function( context ) {
 	return {
 		CallExpression: function( node ) {
@@ -26,11 +34,30 @@ var rule = module.exports = function( context ) {
 
 			node.arguments.forEach( function( arg ) {
 				var argumentString = getTextContentFromNode( arg );
-				if ( argumentString && -1 !== argumentString.indexOf( '...' ) ) {
+				if ( argumentString && containsThreeDots( argumentString ) ) {
 					context.report( {
 						node: arg,
 						message: rule.ERROR_MESSAGE,
 						fix: function( fixer ) {
+							if ( arg.type === 'TemplateLiteral' ) {
+								var fixes = [];
+								arg.quasis.forEach(
+									function( quasi ) {
+										if (
+											quasi.type === 'TemplateElement' &&
+											containsThreeDots( quasi.value.raw )
+										) {
+											fixes.push(
+												fixer.replaceTextRange(
+													[ quasi.start, quasi.end ],
+													replaceThreeDotsWithEllipsis( quasi.value.raw )
+												)
+											);
+										}
+									}
+								);
+								return fixes;
+							}
 							return fixer.replaceText( arg, "'" + argumentString.replace( /\.\.\./g, '…' ) + "'" );
 						},
 					} );

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -25,8 +25,32 @@ function replaceThreeDotsWithEllipsis( string ) {
 	return string.replace( /\.\.\./g, '…' );
 }
 
-function escapeSingleQuote( string ) {
-	return string.replace( /'/g, "\\'" );
+function makeFixerFunction( arg ) {
+	return fixer => {
+		switch ( arg.type ) {
+			case 'TemplateLiteral':
+				return arg.quasis.reduce( ( fixes, quasi ) => {
+					if (
+						'TemplateElement' === quasi.type &&
+						containsThreeDots( quasi.value.raw )
+					) {
+						fixes.push(
+							fixer.replaceTextRange(
+								[ quasi.start, quasi.end ],
+								replaceThreeDotsWithEllipsis( quasi.value.raw )
+							)
+						);
+					}
+					return fixes;
+				}, [] );
+
+			case 'Literal':
+				return [ fixer.replaceText( arg, replaceThreeDotsWithEllipsis( arg.raw ) ) ];
+
+			case 'BinaryExpression':
+				return [ ...makeFixerFunction( arg.left )( fixer ), ...makeFixerFunction( arg.right )( fixer ) ];
+		}
+	};
 }
 
 var rule = module.exports = function( context ) {
@@ -42,31 +66,7 @@ var rule = module.exports = function( context ) {
 					context.report( {
 						node: arg,
 						message: rule.ERROR_MESSAGE,
-						fix: function( fixer ) {
-							if ( arg.type === 'TemplateLiteral' ) {
-								return arg.quasis.reduce( ( fixes, quasi ) => {
-									if (
-										'TemplateElement' === quasi.type &&
-										containsThreeDots( quasi.value.raw )
-									) {
-										fixes.push(
-											fixer.replaceTextRange(
-												[ quasi.start, quasi.end ],
-												replaceThreeDotsWithEllipsis( quasi.value.raw )
-											)
-										);
-									}
-									return fixes;
-								}, [] );
-							}
-							if ( arg.type === 'Literal' ) {
-								return fixer.replaceText( arg, replaceThreeDotsWithEllipsis( arg.raw ) );
-							}
-							return fixer.replaceText( arg,
-								"'" +
-								escapeSingleQuote( replaceThreeDotsWithEllipsis( argumentString ) ) +
-								"'" );
-						},
+						fix: makeFixerFunction( arg ),
 					} );
 				}
 			} );

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -25,6 +25,10 @@ function replaceThreeDotsWithEllipsis( string ) {
 	return string.replace( /\.\.\./g, '…' );
 }
 
+function escapeSingleQuote( string ) {
+	return string.replace( /'/g, "\\'" );
+}
+
 var rule = module.exports = function( context ) {
 	return {
 		CallExpression: function( node ) {
@@ -61,7 +65,10 @@ var rule = module.exports = function( context ) {
 							if ( arg.type === 'Literal' ) {
 								return fixer.replaceText( arg, replaceThreeDotsWithEllipsis( arg.raw ) );
 							}
-							return fixer.replaceText( arg, "'" + replaceThreeDotsWithEllipsis( argumentString ) + "'" );
+							return fixer.replaceText( arg,
+								"'" +
+								escapeSingleQuote( replaceThreeDotsWithEllipsis( argumentString ) ) +
+								"'" );
 						},
 					} );
 				}

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -44,23 +44,20 @@ var rule = module.exports = function( context ) {
 						message: rule.ERROR_MESSAGE,
 						fix: function( fixer ) {
 							if ( arg.type === 'TemplateLiteral' ) {
-								var fixes = [];
-								arg.quasis.forEach(
-									function( quasi ) {
-										if (
-											quasi.type === 'TemplateElement' &&
-											containsThreeDots( quasi.value.raw )
-										) {
-											fixes.push(
-												fixer.replaceTextRange(
-													[ quasi.start, quasi.end ],
-													replaceThreeDotsWithEllipsis( quasi.value.raw )
-												)
-											);
-										}
+								return arg.quasis.reduce( ( fixes, quasi ) => {
+									if (
+										'TemplateElement' === quasi.type &&
+										containsThreeDots( quasi.value.raw )
+									) {
+										fixes.push(
+											fixer.replaceTextRange(
+												[ quasi.start, quasi.end ],
+												replaceThreeDotsWithEllipsis( quasi.value.raw )
+											)
+										);
 									}
-								);
-								return fixes;
+									return fixes;
+								}, [] );
 							}
 							if ( arg.type === 'Literal' ) {
 								return fixer.replaceText( arg, replaceThreeDotsWithEllipsis( arg.raw ) );

--- a/lib/rules/i18n-ellipsis.js
+++ b/lib/rules/i18n-ellipsis.js
@@ -31,7 +31,7 @@ var rule = module.exports = function( context ) {
 						node: arg,
 						message: rule.ERROR_MESSAGE,
 						fix: function( fixer ) {
-							return fixer.replaceText( arg, argumentString.replace( /\.\.\./g, '…' ) );
+							return fixer.replaceText( arg, "'" + argumentString.replace( /\.\.\./g, '…' ) + "'" );
 						},
 					} );
 				}

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -46,36 +46,42 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: 'this.translate( \'Hello World…\' );',
 		},
 		{
 			code: 'i18n.translate( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: 'i18n.translate( \'Hello World…\' );',
 		},
 		{
 			code: 'i18n.translate( `Hello World...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: 'i18n.translate( `Hello World…` );',
 		},
 		{
 			code: 'translate( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: 'translate( \'Hello World…\' );',
 		},
 		{
 			code: 'translate( \'Hello World…\', \'Hello Worlds...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: 'translate( \'Hello World…\', \'Hello Worlds…\' );',
 		},
 		{
 			code: '( 0, translate )( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
+			output: '( 0, translate )( \'Hello World…\' );',
 		},
 	],
 } );

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -60,7 +60,7 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( `Hello World…` );',
+			output: 'i18n.translate( \'Hello World…\' );',
 		},
 		{
 			code: 'translate( \'Hello World...\' );',

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -56,6 +56,13 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			output: 'i18n.translate( \'Hello World…\' );',
 		},
 		{
+			code: 'i18n.translate( \'Fix string containing single quote(\\\')...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( \'Fix string containing single quote(\')…\' );',
+		},
+		{
 			code: 'i18n.translate( `Hello World...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -49,6 +49,13 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			output: 'this.translate( \'Hello World…\' );',
 		},
 		{
+			code: 'this.translate( "Hello World..." );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'this.translate( "Hello World…" );',
+		},
+		{
 			code: 'i18n.translate( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -21,16 +21,22 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 ( new RuleTester( config ) ).run( 'i18n-ellipsis', rule, {
 	valid: [
 		{
-			code: 'this.translate( \'Hello World…\' );',
+			code: 'translate( \'Hello World…\' );',
 		},
 		{
 			code: 'i18n.translate( \'Hello World…\' );',
 		},
 		{
-			code: 'translate( \'Hello World…\' );',
+			code: 'this.translate( \'Hello World…\' );',
+		},
+		{
+			code: 'translate( "Hello World…" );',
 		},
 		{
 			code: 'translate( `Hello World…` );',
+		},
+		{
+			code: 'translate( `Hello ${ World }…` );',
 		},
 		{
 			code: 'translate( \'Hello World…\', \'Hello Worlds…\' );',
@@ -42,18 +48,11 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 
 	invalid: [
 		{
-			code: 'this.translate( \'Hello World...\' );',
+			code: 'translate( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'this.translate( \'Hello World…\' );',
-		},
-		{
-			code: 'this.translate( "Hello World..." );',
-			errors: [ {
-				message: rule.ERROR_MESSAGE,
-			} ],
-			output: 'this.translate( "Hello World…" );',
+			output: 'translate( \'Hello World…\' );',
 		},
 		{
 			code: 'i18n.translate( \'Hello World...\' );',
@@ -63,60 +62,60 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			output: 'i18n.translate( \'Hello World…\' );',
 		},
 		{
-			code: 'i18n.translate( \'Fix string containing single quote(\\\')...\' );',
+			code: 'this.translate( \'Hello World...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix string containing single quote(\\\')…\' );',
+			output: 'this.translate( \'Hello World…\' );',
 		},
 		{
-			code: 'i18n.translate( \'Fix... \' + \'Joined strings...\' );',
+			code: 'translate( "Hello World..." );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix… \' + \'Joined strings…\' );',
+			output: 'translate( "Hello World…" );',
 		},
 		{
-			code: 'i18n.translate( \'Fix single quote \\\' containing \' + \'Joined strings...\' );',
+			code: 'translate( \'Fix... \' + \'Joined strings...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix single quote \\\' containing \' + \'Joined strings…\' );',
+			output: 'translate( \'Fix… \' + \'Joined strings…\' );',
 		},
 		{
-			code: 'i18n.translate( \'Fix ...\' + `Joined template` );',
+			code: 'translate( \'Fix ...\' + `Joined template` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix …\' + `Joined template` );',
+			output: 'translate( \'Fix …\' + `Joined template` );',
 		},
 		{
-			code: 'i18n.translate( \'Fix ...\' + \'Multiple ... \' + \'Binary ...\' );',
+			code: 'translate( \'Fix ...\' + \'Multiple ... \' + \'Joined ...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix …\' + \'Multiple … \' + \'Binary …\' );',
+			output: 'translate( \'Fix …\' + \'Multiple … \' + \'Joined …\' );',
 		},
 		{
-			code: 'i18n.translate( `Hello World...` );',
+			code: 'translate( `Hello World...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( `Hello World…` );',
+			output: 'translate( `Hello World…` );',
 		},
 		{
-			code: 'i18n.translate( `Hello ${ "World" }...` );',
+			code: 'translate( `Hello ${ "World" }...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( `Hello ${ "World" }…` );',
+			output: 'translate( `Hello ${ "World" }…` );',
 		},
 		{
-			code: 'var world = "World"; i18n.translate( `Hello ${ world }...` );',
+			code: 'translate( `Hello ${ world }...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'var world = "World"; i18n.translate( `Hello ${ world }…` );',
+			output: 'translate( `Hello ${ world }…` );',
 		},
 		{
 			code: 'translate( \'Hello World...\' );',

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -70,18 +70,32 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			output: 'i18n.translate( \'Fix string containing single quote(\\\')…\' );',
 		},
 		{
-			code: 'i18n.translate( \'Fix ...\' + \'Joined strings...\' );',
+			code: 'i18n.translate( \'Fix... \' + \'Joined strings...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix …Joined strings…\' );',
+			output: 'i18n.translate( \'Fix… \' + \'Joined strings…\' );',
 		},
 		{
-			code: 'i18n.translate( \'Fix single quote \\\' containing\' + \'Joined strings...\' );',
+			code: 'i18n.translate( \'Fix single quote \\\' containing \' + \'Joined strings...\' );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix single quote \\\' containingJoined strings…\' );',
+			output: 'i18n.translate( \'Fix single quote \\\' containing \' + \'Joined strings…\' );',
+		},
+		{
+			code: 'i18n.translate( \'Fix ...\' + `Joined template` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( \'Fix …\' + `Joined template` );',
+		},
+		{
+			code: 'i18n.translate( \'Fix ...\' + \'Multiple ... \' + \'Binary ...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( \'Fix …\' + \'Multiple … \' + \'Binary …\' );',
 		},
 		{
 			code: 'i18n.translate( `Hello World...` );',

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -60,7 +60,7 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Fix string containing single quote(\')…\' );',
+			output: 'i18n.translate( \'Fix string containing single quote(\\\')…\' );',
 		},
 		{
 			code: 'i18n.translate( `Hello World...` );',

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -63,6 +63,20 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			output: 'i18n.translate( \'Fix string containing single quote(\\\')…\' );',
 		},
 		{
+			code: 'i18n.translate( \'Fix ...\' + \'Joined strings...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( \'Fix …Joined strings…\' );',
+		},
+		{
+			code: 'i18n.translate( \'Fix single quote \\\' containing\' + \'Joined strings...\' );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( \'Fix single quote \\\' containingJoined strings…\' );',
+		},
+		{
 			code: 'i18n.translate( `Hello World...` );',
 			errors: [ {
 				message: rule.ERROR_MESSAGE,

--- a/tests/lib/rules/i18n-ellipsis.js
+++ b/tests/lib/rules/i18n-ellipsis.js
@@ -67,7 +67,21 @@ var rule = require( '../../../lib/rules/i18n-ellipsis' ),
 			errors: [ {
 				message: rule.ERROR_MESSAGE,
 			} ],
-			output: 'i18n.translate( \'Hello World…\' );',
+			output: 'i18n.translate( `Hello World…` );',
+		},
+		{
+			code: 'i18n.translate( `Hello ${ "World" }...` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'i18n.translate( `Hello ${ "World" }…` );',
+		},
+		{
+			code: 'var world = "World"; i18n.translate( `Hello ${ world }...` );',
+			errors: [ {
+				message: rule.ERROR_MESSAGE,
+			} ],
+			output: 'var world = "World"; i18n.translate( `Hello ${ world }…` );',
 		},
 		{
 			code: 'translate( \'Hello World...\' );',


### PR DESCRIPTION
Adds test for `i18n-ellipsis` fix.
Wraps fixed `i18n-ellipsis` in quotes.

~This fix continues to have problems with strings and interpolation:~ I believe this is tested and fixed now.

```js
translate( `Hello ${ "World" }...` );

// becomes

translate( 'Hello …' );
```

I believe there is another lint rule for use of variables within translated strings. If `translate` is being used correctly this shouldn't be an issue, but that's what the linter is for, isn't it 🙂 

~I'd like to find a more robust solution~ 🤔  I think we're good now 👍 

Fixes #44 